### PR TITLE
Fix usage of non-optional Parse.currentConfiguration().

### DIFF
--- a/Examples/LiveQueryDemo.xcodeproj/project.pbxproj
+++ b/Examples/LiveQueryDemo.xcodeproj/project.pbxproj
@@ -8,11 +8,35 @@
 
 /* Begin PBXBuildFile section */
 		7F64F07377979A28C88AF3AE /* Pods_LiveQueryDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6A6F02FD57E57309877DA38 /* Pods_LiveQueryDemo.framework */; };
+		8199A4091CA1EF3300BF61E1 /* ParseLiveQuery.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8199A4061CA1EF1800BF61E1 /* ParseLiveQuery.framework */; };
 		F59F85B01C9BB48200566A29 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59F85AF1C9BB48200566A29 /* main.swift */; };
 		F59F85B81C9BB4B600566A29 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59F85B61C9BB4B600566A29 /* Message.swift */; };
 		F59F85B91C9BB4B600566A29 /* Room.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59F85B71C9BB4B600566A29 /* Room.swift */; };
-		F59F85BD1C9BB66C00566A29 /* ParseLiveQuery.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F59F85BC1C9BB66C00566A29 /* ParseLiveQuery.framework */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		8199A4031CA1EF1800BF61E1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8199A3FE1CA1EF1800BF61E1 /* ParseLiveQuery.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F5A9BFCA1BE0248D00E78326;
+			remoteInfo = "ParseLiveQuery-iOS";
+		};
+		8199A4051CA1EF1800BF61E1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8199A3FE1CA1EF1800BF61E1 /* ParseLiveQuery.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F5903CEA1BD999C500C3EFFE;
+			remoteInfo = "ParseLiveQuery-OSX";
+		};
+		8199A4071CA1EF2100BF61E1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8199A3FE1CA1EF1800BF61E1 /* ParseLiveQuery.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = F5903CE91BD999C500C3EFFE;
+			remoteInfo = "ParseLiveQuery-OSX";
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		F59F85AA1C9BB48200566A29 /* CopyFiles */ = {
@@ -29,6 +53,7 @@
 /* Begin PBXFileReference section */
 		3AC9312CEDA0007F8EAA9880 /* Pods-LiveQueryDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LiveQueryDemo.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-LiveQueryDemo/Pods-LiveQueryDemo.debug.xcconfig"; sourceTree = "<group>"; };
 		497772719B97C861F0896BFC /* Pods-LiveQueryDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LiveQueryDemo.release.xcconfig"; path = "../Pods/Target Support Files/Pods-LiveQueryDemo/Pods-LiveQueryDemo.release.xcconfig"; sourceTree = "<group>"; };
+		8199A3FE1CA1EF1800BF61E1 /* ParseLiveQuery.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ParseLiveQuery.xcodeproj; path = ../Sources/ParseLiveQuery.xcodeproj; sourceTree = "<group>"; };
 		E6A6F02FD57E57309877DA38 /* Pods_LiveQueryDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LiveQueryDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F59F85AC1C9BB48200566A29 /* LiveQueryDemo */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = LiveQueryDemo; sourceTree = BUILT_PRODUCTS_DIR; };
 		F59F85AF1C9BB48200566A29 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -42,7 +67,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F59F85BD1C9BB66C00566A29 /* ParseLiveQuery.framework in Frameworks */,
+				8199A4091CA1EF3300BF61E1 /* ParseLiveQuery.framework in Frameworks */,
 				7F64F07377979A28C88AF3AE /* Pods_LiveQueryDemo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -53,10 +78,20 @@
 		2E2DAD338FCB65EC95CB7AA9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				8199A3FE1CA1EF1800BF61E1 /* ParseLiveQuery.xcodeproj */,
 				F59F85BC1C9BB66C00566A29 /* ParseLiveQuery.framework */,
 				E6A6F02FD57E57309877DA38 /* Pods_LiveQueryDemo.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		8199A3FF1CA1EF1800BF61E1 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8199A4041CA1EF1800BF61E1 /* ParseLiveQuery.framework */,
+				8199A4061CA1EF1800BF61E1 /* ParseLiveQuery.framework */,
+			);
+			name = Products;
 			sourceTree = "<group>";
 		};
 		B4367C9D9257525F9D28B542 /* Pods */ = {
@@ -114,6 +149,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				8199A4081CA1EF2100BF61E1 /* PBXTargetDependency */,
 			);
 			name = LiveQueryDemo;
 			productName = LiveQueryDemo;
@@ -145,12 +181,35 @@
 			mainGroup = F59F85A31C9BB48200566A29;
 			productRefGroup = F59F85AD1C9BB48200566A29 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 8199A3FF1CA1EF1800BF61E1 /* Products */;
+					ProjectRef = 8199A3FE1CA1EF1800BF61E1 /* ParseLiveQuery.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				F59F85AB1C9BB48200566A29 /* LiveQueryDemo */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		8199A4041CA1EF1800BF61E1 /* ParseLiveQuery.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ParseLiveQuery.framework;
+			remoteRef = 8199A4031CA1EF1800BF61E1 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8199A4061CA1EF1800BF61E1 /* ParseLiveQuery.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ParseLiveQuery.framework;
+			remoteRef = 8199A4051CA1EF1800BF61E1 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		15BD0AAA808A79D4D9BF001B /* 📦 Check Pods Manifest.lock */ = {
@@ -197,6 +256,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		8199A4081CA1EF2100BF61E1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ParseLiveQuery-OSX";
+			targetProxy = 8199A4071CA1EF2100BF61E1 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		F59F85B11C9BB48200566A29 /* Debug */ = {

--- a/Examples/LiveQueryDemo.xcodeproj/xcshareddata/xcschemes/LiveQueryDemo.xcscheme
+++ b/Examples/LiveQueryDemo.xcodeproj/xcshareddata/xcschemes/LiveQueryDemo.xcscheme
@@ -3,23 +3,9 @@
    LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F5903CE91BD999C500C3EFFE"
-               BuildableName = "ParseLiveQuery.framework"
-               BlueprintName = "ParseLiveQuery-OSX"
-               ReferencedContainer = "container:../Sources/ParseLiveQuery.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - Bolts-Swift (1.0.0)
   - Bolts/Tasks (1.6.0)
-  - Parse (1.12.0):
-    - Bolts/Tasks (~> 1.5)
+  - Parse (1.13.0):
+    - Bolts/Tasks (~> 1.6)
   - SocketRocket (0.5.0)
 
 DEPENDENCIES:
@@ -13,7 +13,7 @@ DEPENDENCIES:
 SPEC CHECKSUMS:
   Bolts: f52a250053bb517ca874523c3913776359ab3def
   Bolts-Swift: 1b20170f1edf3568ec62142ea16ecdc369deced7
-  Parse: de2c52a9a1421b91ae7594ab8ce191afd184f19b
+  Parse: f51c24d2feb412e4b2d6cc73d37cb24e8d0089bc
   SocketRocket: 2c51efccd2d73c99a923407ca4b06e7e9da95dbf
 
 PODFILE CHECKSUM: b9a8e3333816abb217972f59b02783395bc8c2e2

--- a/Sources/ParseLiveQuery.xcodeproj/project.pbxproj
+++ b/Sources/ParseLiveQuery.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0632EDD41CA1A6DB00DD3CB8 /* Parse+LiveQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0632EDD31CA1A6DB00DD3CB8 /* Parse+LiveQuery.swift */; };
+		0632EDD51CA1A6DB00DD3CB8 /* Parse+LiveQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0632EDD31CA1A6DB00DD3CB8 /* Parse+LiveQuery.swift */; };
 		629DC3BE90DA87A7857677D2 /* Pods_ParseLiveQuery_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE2643D85A7565FC20EE144C /* Pods_ParseLiveQuery_iOS.framework */; };
 		DE7126BDB27E5DDB1C21490A /* Pods_ParseLiveQuery_OSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF5A55E51D52E372CD28FF08 /* Pods_ParseLiveQuery_OSX.framework */; };
 		F534A5B21BDAFE0200CBD11A /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = F534A5B11BDAFE0200CBD11A /* Subscription.swift */; };
@@ -30,6 +32,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0632EDD31CA1A6DB00DD3CB8 /* Parse+LiveQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Parse+LiveQuery.swift"; sourceTree = "<group>"; };
 		11F6DFE2732DB0DE49976BA5 /* Pods-ParseLiveQuery OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ParseLiveQuery OSX.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ParseLiveQuery OSX/Pods-ParseLiveQuery OSX.release.xcconfig"; sourceTree = "<group>"; };
 		6062D7994653A4F07D1358B9 /* Pods-ParseLiveQuery iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ParseLiveQuery iOS.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-ParseLiveQuery iOS/Pods-ParseLiveQuery iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		7A40A16386D0D6B38F8B2F07 /* Pods-ParseLiveQuery-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ParseLiveQuery-iOS.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ParseLiveQuery-iOS/Pods-ParseLiveQuery-iOS.release.xcconfig"; sourceTree = "<group>"; };
@@ -128,6 +131,7 @@
 				F534A5B11BDAFE0200CBD11A /* Subscription.swift */,
 				F54D58B51C8E33D9009F8D6C /* ObjCCompat.swift */,
 				F59CA92E1C8E496200329737 /* Errors.swift */,
+				0632EDD31CA1A6DB00DD3CB8 /* Parse+LiveQuery.swift */,
 				F5A88F491C9B6EBA002F0E0D /* PFQuery+Subscribe.swift */,
 			);
 			path = ParseLiveQuery;
@@ -324,6 +328,7 @@
 			files = (
 				F54D58B81C8E3446009F8D6C /* ClientPrivate.swift in Sources */,
 				F5D965351BD99DA200C3AAFC /* Client.swift in Sources */,
+				0632EDD51CA1A6DB00DD3CB8 /* Parse+LiveQuery.swift in Sources */,
 				F54D58B61C8E33D9009F8D6C /* ObjCCompat.swift in Sources */,
 				F54D58BA1C8E345F009F8D6C /* BoltsHelpers.swift in Sources */,
 				F5D965381BD99DA200C3AAFC /* QueryEncoder.swift in Sources */,
@@ -340,6 +345,7 @@
 			files = (
 				F5A88F541C9B7341002F0E0D /* ObjCCompat.swift in Sources */,
 				F5A88F531C9B7341002F0E0D /* Subscription.swift in Sources */,
+				0632EDD41CA1A6DB00DD3CB8 /* Parse+LiveQuery.swift in Sources */,
 				F5A88F511C9B7341002F0E0D /* BoltsHelpers.swift in Sources */,
 				F5A88F501C9B7341002F0E0D /* ClientPrivate.swift in Sources */,
 				F5A88F551C9B7341002F0E0D /* Errors.swift in Sources */,

--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -33,11 +33,10 @@ public class Client: NSObject {
     internal let queue = dispatch_queue_create("com.parse.livequery", DISPATCH_QUEUE_SERIAL)
 
     /**
-     Creates a Client which automatically attempts to connect to the custom parse-server URL set
-     in Parse.currentConfiguration
+     Creates a Client which automatically attempts to connect to the custom parse-server URL set in Parse.currentConfiguration().
      */
     public override convenience init() {
-        self.init(server: Parse.currentConfiguration().server)
+        self.init(server: Parse.validatedCurrentConfiguration().server)
     }
 
     /**
@@ -61,8 +60,8 @@ public class Client: NSObject {
             return RequestId(value: currentRequestId)
         }
 
-        self.applicationId = applicationId ?? Parse.currentConfiguration().applicationId!
-        self.clientKey = clientKey ?? Parse.currentConfiguration().clientKey
+        self.applicationId = applicationId ?? Parse.validatedCurrentConfiguration().applicationId!
+        self.clientKey = clientKey ?? Parse.validatedCurrentConfiguration().clientKey
 
         self.host = components.URL!
     }
@@ -94,7 +93,7 @@ extension Client {
             dispatch_sync(storage.queue) {
                 client = storage.client
                 if client == nil {
-                    let configuration = Parse.currentConfiguration()
+                    let configuration = Parse.validatedCurrentConfiguration()
                     client = Client(
                         server: configuration.server,
                         applicationId: configuration.applicationId,

--- a/Sources/ParseLiveQuery/Parse+LiveQuery.swift
+++ b/Sources/ParseLiveQuery/Parse+LiveQuery.swift
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2016-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import Parse
+
+extension Parse {
+    static func validatedCurrentConfiguration() -> ParseClientConfiguration {
+        guard let configuration = Parse.currentConfiguration() else {
+            preconditionFailure("Parse SDK is not initialized. Call Parse.initializeWithConfiguration() before loading live query client.")
+        }
+        return configuration
+    }
+}


### PR DESCRIPTION
Parse 1.13.0 declares `currentConfiguration()` as optional (nullable), so we need to unwrap it properly.
Added validation logic so we make sure that whenever we ask for `currentConfiguration()` Parse SDK is fully initialized.

Fixes #2 
