### PR TITLE
Remove all usages of the internal keyword

### DIFF
--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -18,19 +18,19 @@ import SocketRocket
  */
 @objc(PFLiveQueryClient)
 public class Client: NSObject {
-    internal let host: NSURL
-    internal let applicationId: String
-    internal let clientKey: String?
+    let host: NSURL
+    let applicationId: String
+    let clientKey: String?
 
-    internal var socket: SRWebSocket?
-    internal var disconnected = false
+    var socket: SRWebSocket?
+    var disconnected = false
 
     // This allows us to easily plug in another request ID generation scheme, or more easily change the request id type
     // if needed (technically this could be a string).
-    internal let requestIdGenerator: () -> RequestId
-    internal var subscriptions = [SubscriptionRecord]()
+    let requestIdGenerator: () -> RequestId
+    var subscriptions = [SubscriptionRecord]()
 
-    internal let queue = dispatch_queue_create("com.parse.livequery", DISPATCH_QUEUE_SERIAL)
+    let queue = dispatch_queue_create("com.parse.livequery", DISPATCH_QUEUE_SERIAL)
 
     /**
      Creates a Client which automatically attempts to connect to the custom parse-server URL set in Parse.currentConfiguration().
@@ -180,7 +180,7 @@ extension Client {
         unsubscribe { $0.query == query && $0.subscriptionHandler === handler }
     }
 
-    internal func unsubscribe(@noescape matching matcher: SubscriptionRecord -> Bool) {
+    func unsubscribe(@noescape matching matcher: SubscriptionRecord -> Bool) {
         subscriptions.filter {
             matcher($0)
         }.forEach {

--- a/Sources/ParseLiveQuery/Internal/BoltsHelpers.swift
+++ b/Sources/ParseLiveQuery/Internal/BoltsHelpers.swift
@@ -10,9 +10,9 @@
 import Bolts
 import BoltsSwift
 
-internal let unknownDomain = "unknown"
+let unknownDomain = "unknown"
 
-internal func objcTask<T where T: AnyObject>(task: Task<T>) -> BFTask {
+func objcTask<T where T: AnyObject>(task: Task<T>) -> BFTask {
     let taskCompletionSource = BFTaskCompletionSource()
     task.continueWith { task in
         if task.cancelled {
@@ -27,7 +27,7 @@ internal func objcTask<T where T: AnyObject>(task: Task<T>) -> BFTask {
     return taskCompletionSource.task
 }
 
-internal func swiftTask(task: BFTask) -> Task<AnyObject> {
+func swiftTask(task: BFTask) -> Task<AnyObject> {
     let taskCompletionSource = TaskCompletionSource<AnyObject>()
     task.continueWithBlock { task in
         if task.cancelled {

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -21,6 +21,7 @@ private func parseObject<T: PFObject>(objectDictionary: [String:AnyObject]) thro
     }
 
     let parseObject = T(withoutDataWithClassName: parseClassName, objectId: objectId)
+
     objectDictionary.filter { key, _ in
         key != "parseClassName" && key != "objectId"
         }.forEach { key, value in
@@ -33,8 +34,8 @@ private func parseObject<T: PFObject>(objectDictionary: [String:AnyObject]) thro
 // MARK: Subscriptions
 // ---------------
 
-internal extension Client {
-    internal class SubscriptionRecord {
+extension Client {
+    class SubscriptionRecord {
         weak var subscriptionHandler: AnyObject?
 
         // HandlerClosure captures the generic type info passed into the constructor of SubscriptionRecord,
@@ -99,10 +100,10 @@ internal extension Client {
 
     // An opaque placeholder structed used to ensure that we type-safely create request IDs and don't shoot ourself in
     // the foot with array indexes.
-    internal struct RequestId: Equatable {
-        internal let value: Int
+    struct RequestId: Equatable {
+        let value: Int
 
-        internal init(value: Int) {
+        init(value: Int) {
             self.value = value
         }
     }
@@ -155,7 +156,7 @@ extension Client: SRWebSocketDelegate {
 // MARK: Operations
 // -------------------
 
-internal extension Event {
+extension Event {
     init(serverResponse: ServerResponse, inout requestId: Client.RequestId) throws {
         switch serverResponse {
         case .Enter(let reqId, let object):
@@ -183,7 +184,7 @@ internal extension Event {
     }
 }
 
-internal extension Client {
+extension Client {
     private func subscriptionRecord(requestId: RequestId) -> SubscriptionRecord? {
         guard
             let recordIndex = self.subscriptions.indexOf({ $0.requestId == requestId }),
@@ -195,7 +196,7 @@ internal extension Client {
         return record
     }
 
-    internal func sendOperationAsync(operation: ClientOperation) -> Task<Void> {
+    func sendOperationAsync(operation: ClientOperation) -> Task<Void> {
         return Task(.Queue(queue)) {
             let jsonEncoded = operation.JSONObjectRepresentation
             let jsonData = try NSJSONSerialization.dataWithJSONObject(jsonEncoded, options: NSJSONWritingOptions(rawValue: 0))
@@ -205,7 +206,7 @@ internal extension Client {
         }
     }
 
-    internal func handleOperationAsync(string: String) -> Task<Void> {
+    func handleOperationAsync(string: String) -> Task<Void> {
         return Task(.Queue(queue)) {
             guard
                 let jsonData = string.dataUsingEncoding(NSUTF8StringEncoding),

--- a/Sources/ParseLiveQuery/Internal/Operation.swift
+++ b/Sources/ParseLiveQuery/Internal/Operation.swift
@@ -10,7 +10,7 @@
 import Foundation
 import Parse
 
-internal enum ClientOperation {
+enum ClientOperation {
     case Connect(applicationId: String, sessionToken: String)
     case Subscribe(requestId: Client.RequestId, query: PFQuery)
     case Unsubscribe(requestId: Client.RequestId)
@@ -29,7 +29,7 @@ internal enum ClientOperation {
     }
 }
 
-internal enum ServerResponse {
+enum ServerResponse {
     case Redirect(url: String)
     case Connected()
 
@@ -44,7 +44,7 @@ internal enum ServerResponse {
 
     case Error(requestId: Client.RequestId?, code: Int, error: String, reconnect: Bool)
 
-    internal init(json: [String : AnyObject]) throws {
+    init(json: [String : AnyObject]) throws {
         func jsonValue<T>(json: [String:AnyObject], _ key: String) throws -> T {
             guard let value =  json[key] as? T
                 else {

--- a/Sources/ParseLiveQuery/Internal/QueryEncoder.swift
+++ b/Sources/ParseLiveQuery/Internal/QueryEncoder.swift
@@ -13,8 +13,8 @@ import Parse
 /**
  NOTE: This is super hacky, and we need a better answer for this.
  */
-internal extension Dictionary where Key: StringLiteralConvertible, Value: AnyObject {
-    internal init(query: PFQuery) {
+extension Dictionary where Key: StringLiteralConvertible, Value: AnyObject {
+    init(query: PFQuery) {
         self.init()
 
         let queryState = query.valueForKey("state")

--- a/Sources/ParseLiveQuery/ObjCCompat.swift
+++ b/Sources/ParseLiveQuery/ObjCCompat.swift
@@ -122,10 +122,10 @@ public struct ObjCCompat {
         public typealias EventHandler = @convention(block) (PFQuery, Event) -> Void
         public typealias ObjectHandler = @convention(block) (PFQuery, PFObject) -> Void
 
-        internal var subscribeHandlers = [SubscribeHandler]()
-        internal var unsubscribeHandlers = [SubscribeHandler]()
-        internal var errorHandlers = [ErrorHandler]()
-        internal var eventHandlers = [EventHandler]()
+        var subscribeHandlers = [SubscribeHandler]()
+        var unsubscribeHandlers = [SubscribeHandler]()
+        var errorHandlers = [ErrorHandler]()
+        var eventHandlers = [EventHandler]()
 
         /**
          Register a callback for when a client succesfully subscribes to a query.

--- a/Sources/ParseLiveQuery/Subscription.swift
+++ b/Sources/ParseLiveQuery/Subscription.swift
@@ -84,7 +84,7 @@ public enum Event<T where T: PFObject> {
     /// The object has been deleted, and is no longer included in the query
     case Deleted(T)
 
-    internal init<V where V: PFObject>(event: Event<V>) {
+    init<V where V: PFObject>(event: Event<V>) {
         switch event {
         case .Entered(let value as T): self = .Entered(value)
         case .Left(let value as T):    self = .Left(value)


### PR DESCRIPTION
This is mostly redundant and can hurt readability for people new to
swift.
