### PR TITLE
Fix for multiple subscription requests.

### DIFF
--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -21,26 +21,28 @@ public class Client: NSObject {
     let host: NSURL
     let applicationId: String
     let clientKey: String?
-    
+
     var socket: SRWebSocket?
     
+    var userDisconnected = false
+
     // This allows us to easily plug in another request ID generation scheme, or more easily change the request id type
     // if needed (technically this could be a string).
     let requestIdGenerator: () -> RequestId
     var subscriptions = [SubscriptionRecord]()
-    
+
     let queue = dispatch_queue_create("com.parse.livequery", DISPATCH_QUEUE_SERIAL)
-    
+
     /**
      Creates a Client which automatically attempts to connect to the custom parse-server URL set in Parse.currentConfiguration().
      */
     public override convenience init() {
         self.init(server: Parse.validatedCurrentConfiguration().server)
     }
-    
+
     /**
      Creates a client which will connect to a specific server with an optional application id and client key
-     
+
      - parameter server:        The server to connect to
      - parameter applicationId: The application id to use
      - parameter clientKey:     The client key to use
@@ -51,17 +53,17 @@ public class Client: NSObject {
         }
         components.scheme = "ws"
         components.path = "/LQ"
-        
+
         // Simple incrementing generator - can't use ++, that operator is deprecated!
         var currentRequestId = 0
         requestIdGenerator = {
             currentRequestId += 1
             return RequestId(value: currentRequestId)
         }
-        
+
         self.applicationId = applicationId ?? Parse.validatedCurrentConfiguration().applicationId!
         self.clientKey = clientKey ?? Parse.validatedCurrentConfiguration().clientKey
-        
+
         self.host = components.URL!
     }
 }
@@ -78,11 +80,11 @@ extension Client {
             }
             return sharedStorage
         }
-        
+
         let queue: dispatch_queue_t = dispatch_queue_create("com.parse.livequery.client.storage", DISPATCH_QUEUE_SERIAL)
         var client: Client?
     }
-    
+
     /// Gets or sets shared live query client to be used for default subscriptions
     @objc(sharedClient)
     public static var shared: Client! {
@@ -115,73 +117,75 @@ extension Client {
 extension Client {
     /**
      Registers a query for live updates, using the default subscription handler
-     
+
      - parameter query:        The query to register for updates.
      - parameter subclassType: The subclass of PFObject to be used as the type of the Subscription.
-     This parameter can be automatically inferred from context most of the time
-     
+                               This parameter can be automatically inferred from context most of the time
+
      - returns: The subscription that has just been registered
      */
     public func subscribe<T where T: PFObject>(
         query: PFQuery,
         subclassType: T.Type = T.self
         ) -> Subscription<T> {
-        return subscribe(query, handler: Subscription<T>())
+            return subscribe(query, handler: Subscription<T>())
     }
-    
+
     /**
      Registers a query for live updates, using a custom subscription handler
-     
+
      - parameter query:   The query to register for updates.
      - parameter handler: A custom subscription handler.
-     
+
      - returns: Your subscription handler, for easy chaining.
      */
     public func subscribe<T where T: SubscriptionHandling>(
         query: PFQuery,
         handler: T
         ) -> T {
-        let subscriptionRecord = SubscriptionRecord(
-            query: query,
-            requestId: requestIdGenerator(),
-            handler: handler
-        )
-        subscriptions.append(subscriptionRecord)
-        
+            let subscriptionRecord = SubscriptionRecord(
+                query: query,
+                requestId: requestIdGenerator(),
+                handler: handler
+            )
+            subscriptions.append(subscriptionRecord)
+
         if socket == nil || socket?.readyState == .CLOSED{
+            userDisconnected = false
             reconnect()
         } else if socket?.readyState == .OPEN{
+            
             sendOperationAsync(.Subscribe(requestId: subscriptionRecord.requestId, query: query))
         }
-        
-        return handler
+
+            return handler
     }
-    
+
     /**
      Unsubscribes all current subscriptions for a given query.
-     
+
      - parameter query: The query to unsubscribe from.
      */
     @objc(unsubscribeFromQuery:)
     public func unsubscribe(query: PFQuery) {
         unsubscribe { $0.query == query }
     }
-    
+
     /**
      Unsubscribes from a specific query-handler pair.
-     
+
      - parameter query:   The query to unsubscribe from.
      - parameter handler: The specific handler to unsubscribe from.
      */
     public func unsubscribe<T where T: SubscriptionHandling>(query: PFQuery, handler: T) {
         unsubscribe { $0.query == query && $0.subscriptionHandler === handler }
     }
-    
+
     func unsubscribe(@noescape matching matcher: SubscriptionRecord -> Bool) {
         subscriptions.filter {
             matcher($0)
-            }.forEach {
-                sendOperationAsync(.Unsubscribe(requestId: $0.requestId))
+        }.forEach {
+            sendOperationAsync(.Unsubscribe(requestId: $0.requestId))
         }
     }
 }
@@ -189,7 +193,7 @@ extension Client {
 extension Client {
     /**
      Reconnects this client to the server.
-     
+
      This will disconnect and resubscribe all existing subscriptions. This is not required to be called the first time
      you use the client, and should usually only be called when an error occurs.
      */
@@ -200,14 +204,14 @@ extension Client {
             socket.delegate = self
             socket.setDelegateDispatchQueue(queue)
             socket.open()
-            
+
             return socket
             }()
     }
-    
+
     /**
      Explicitly disconnects this client from the server.
-     
+
      This does not remove any subscriptions - if you `reconnect()` your existing subscriptions will be restored.
      Use this if you wish to dispose of the live query client.
      */
@@ -218,5 +222,6 @@ extension Client {
         }
         socket.close()
         self.socket = nil
+        userDisconnected = true
     }
 }

--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -21,27 +21,27 @@ public class Client: NSObject {
     let host: NSURL
     let applicationId: String
     let clientKey: String?
-    
+
     var socket: SRWebSocket?
     var userDisconnected = false
-    
+
     // This allows us to easily plug in another request ID generation scheme, or more easily change the request id type
     // if needed (technically this could be a string).
     let requestIdGenerator: () -> RequestId
     var subscriptions = [SubscriptionRecord]()
-    
+
     let queue = dispatch_queue_create("com.parse.livequery", DISPATCH_QUEUE_SERIAL)
-    
+
     /**
      Creates a Client which automatically attempts to connect to the custom parse-server URL set in Parse.currentConfiguration().
      */
     public override convenience init() {
         self.init(server: Parse.validatedCurrentConfiguration().server)
     }
-    
+
     /**
      Creates a client which will connect to a specific server with an optional application id and client key
-     
+
      - parameter server:        The server to connect to
      - parameter applicationId: The application id to use
      - parameter clientKey:     The client key to use
@@ -52,17 +52,17 @@ public class Client: NSObject {
         }
         components.scheme = "ws"
         components.path = "/LQ"
-        
+
         // Simple incrementing generator - can't use ++, that operator is deprecated!
         var currentRequestId = 0
         requestIdGenerator = {
             currentRequestId += 1
             return RequestId(value: currentRequestId)
         }
-        
+
         self.applicationId = applicationId ?? Parse.validatedCurrentConfiguration().applicationId!
         self.clientKey = clientKey ?? Parse.validatedCurrentConfiguration().clientKey
-        
+
         self.host = components.URL!
     }
 }
@@ -79,11 +79,11 @@ extension Client {
             }
             return sharedStorage
         }
-        
+
         let queue: dispatch_queue_t = dispatch_queue_create("com.parse.livequery.client.storage", DISPATCH_QUEUE_SERIAL)
         var client: Client?
     }
-    
+
     /// Gets or sets shared live query client to be used for default subscriptions
     @objc(sharedClient)
     public static var shared: Client! {
@@ -116,11 +116,11 @@ extension Client {
 extension Client {
     /**
      Registers a query for live updates, using the default subscription handler
-     
+
      - parameter query:        The query to register for updates.
      - parameter subclassType: The subclass of PFObject to be used as the type of the Subscription.
      This parameter can be automatically inferred from context most of the time
-     
+
      - returns: The subscription that has just been registered
      */
     public func subscribe<T where T: PFObject>(
@@ -129,13 +129,13 @@ extension Client {
         ) -> Subscription<T> {
         return subscribe(query, handler: Subscription<T>())
     }
-    
+
     /**
      Registers a query for live updates, using a custom subscription handler
-     
+
      - parameter query:   The query to register for updates.
      - parameter handler: A custom subscription handler.
-     
+
      - returns: Your subscription handler, for easy chaining.
      */
     public func subscribe<T where T: SubscriptionHandling>(
@@ -161,17 +161,17 @@ extension Client {
         
         return handler
     }
-    
+
     /**
      Unsubscribes all current subscriptions for a given query.
-     
+
      - parameter query: The query to unsubscribe from.
      */
     @objc(unsubscribeFromQuery:)
     public func unsubscribe(query: PFQuery) {
         unsubscribe { $0.query == query }
     }
-    
+
     /**
      Unsubscribes from a specific query-handler pair.
      
@@ -181,7 +181,7 @@ extension Client {
     public func unsubscribe<T where T: SubscriptionHandling>(query: PFQuery, handler: T) {
         unsubscribe { $0.query == query && $0.subscriptionHandler === handler }
     }
-    
+
     func unsubscribe(@noescape matching matcher: SubscriptionRecord -> Bool) {
         subscriptions.filter {
             matcher($0)
@@ -195,7 +195,7 @@ extension Client {
 extension Client {
     /**
      Reconnects this client to the server.
-     
+
      This will disconnect and resubscribe all existing subscriptions. This is not required to be called the first time
      you use the client, and should usually only be called when an error occurs.
      */
@@ -210,10 +210,10 @@ extension Client {
             return socket
             }()
     }
-    
+
     /**
      Explicitly disconnects this client from the server.
-     
+
      This does not remove any subscriptions - if you `reconnect()` your existing subscriptions will be restored.
      Use this if you wish to dispose of the live query client.
      */

--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -23,7 +23,6 @@ public class Client: NSObject {
     let clientKey: String?
     
     var socket: SRWebSocket?
-    
     var userDisconnected = false
     
     // This allows us to easily plug in another request ID generation scheme, or more easily change the request id type

--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -149,12 +149,12 @@ extension Client {
         )
         subscriptions.append(subscriptionRecord)
         
-        if socket?.readyState == .OPEN{
+        if socket?.readyState == .OPEN {
             sendOperationAsync(.Subscribe(requestId: subscriptionRecord.requestId, query: query))
-        } else if socket == nil || socket?.readyState != .CONNECTING{
-            if !userDisconnected{
+        } else if socket == nil || socket?.readyState != .CONNECTING {
+            if !userDisconnected {
                 reconnect()
-            }else{
+            } else {
                 print("Warning: The client was explicitly disconnected! You must explicitly call .reconnect() in order to process your subscriptions.")
             }
         }

--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -155,7 +155,7 @@ extension Client {
             if !userDisconnected {
                 reconnect()
             } else {
-                print("Warning: The client was explicitly disconnected! You must explicitly call .reconnect() in order to process your subscriptions.")
+                debugPrint("Warning: The client was explicitly disconnected! You must explicitly call .reconnect() in order to process your subscriptions.")
             }
         }
         

--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -150,9 +150,14 @@ extension Client {
             )
             subscriptions.append(subscriptionRecord)
 
-        if socket == nil || socket?.readyState == .CLOSED{
-            userDisconnected = false
-            reconnect()
+        if socket == nil || socket?.readyState != .OPEN{
+            
+            if !userDisconnected{
+                reconnect()
+            }else{
+                print("Warning: The client was explicitly disconnected! You must explicitly call .reconnect() in order to process your subscriptions.")
+            }
+            
         } else if socket?.readyState == .OPEN{
             
             sendOperationAsync(.Subscribe(requestId: subscriptionRecord.requestId, query: query))
@@ -188,6 +193,7 @@ extension Client {
             sendOperationAsync(.Unsubscribe(requestId: $0.requestId))
         }
     }
+    
 }
 
 extension Client {
@@ -204,7 +210,7 @@ extension Client {
             socket.delegate = self
             socket.setDelegateDispatchQueue(queue)
             socket.open()
-
+            userDisconnected = true
             return socket
             }()
     }

--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -21,28 +21,28 @@ public class Client: NSObject {
     let host: NSURL
     let applicationId: String
     let clientKey: String?
-
+    
     var socket: SRWebSocket?
     
     var userDisconnected = false
-
+    
     // This allows us to easily plug in another request ID generation scheme, or more easily change the request id type
     // if needed (technically this could be a string).
     let requestIdGenerator: () -> RequestId
     var subscriptions = [SubscriptionRecord]()
-
+    
     let queue = dispatch_queue_create("com.parse.livequery", DISPATCH_QUEUE_SERIAL)
-
+    
     /**
      Creates a Client which automatically attempts to connect to the custom parse-server URL set in Parse.currentConfiguration().
      */
     public override convenience init() {
         self.init(server: Parse.validatedCurrentConfiguration().server)
     }
-
+    
     /**
      Creates a client which will connect to a specific server with an optional application id and client key
-
+     
      - parameter server:        The server to connect to
      - parameter applicationId: The application id to use
      - parameter clientKey:     The client key to use
@@ -53,17 +53,17 @@ public class Client: NSObject {
         }
         components.scheme = "ws"
         components.path = "/LQ"
-
+        
         // Simple incrementing generator - can't use ++, that operator is deprecated!
         var currentRequestId = 0
         requestIdGenerator = {
             currentRequestId += 1
             return RequestId(value: currentRequestId)
         }
-
+        
         self.applicationId = applicationId ?? Parse.validatedCurrentConfiguration().applicationId!
         self.clientKey = clientKey ?? Parse.validatedCurrentConfiguration().clientKey
-
+        
         self.host = components.URL!
     }
 }
@@ -80,11 +80,11 @@ extension Client {
             }
             return sharedStorage
         }
-
+        
         let queue: dispatch_queue_t = dispatch_queue_create("com.parse.livequery.client.storage", DISPATCH_QUEUE_SERIAL)
         var client: Client?
     }
-
+    
     /// Gets or sets shared live query client to be used for default subscriptions
     @objc(sharedClient)
     public static var shared: Client! {
@@ -117,80 +117,77 @@ extension Client {
 extension Client {
     /**
      Registers a query for live updates, using the default subscription handler
-
+     
      - parameter query:        The query to register for updates.
      - parameter subclassType: The subclass of PFObject to be used as the type of the Subscription.
-                               This parameter can be automatically inferred from context most of the time
-
+     This parameter can be automatically inferred from context most of the time
+     
      - returns: The subscription that has just been registered
      */
     public func subscribe<T where T: PFObject>(
         query: PFQuery,
         subclassType: T.Type = T.self
         ) -> Subscription<T> {
-            return subscribe(query, handler: Subscription<T>())
+        return subscribe(query, handler: Subscription<T>())
     }
-
+    
     /**
      Registers a query for live updates, using a custom subscription handler
-
+     
      - parameter query:   The query to register for updates.
      - parameter handler: A custom subscription handler.
-
+     
      - returns: Your subscription handler, for easy chaining.
      */
     public func subscribe<T where T: SubscriptionHandling>(
         query: PFQuery,
         handler: T
         ) -> T {
-            let subscriptionRecord = SubscriptionRecord(
-                query: query,
-                requestId: requestIdGenerator(),
-                handler: handler
-            )
-            subscriptions.append(subscriptionRecord)
-
-        if socket == nil || socket?.readyState != .OPEN{
-            
+        let subscriptionRecord = SubscriptionRecord(
+            query: query,
+            requestId: requestIdGenerator(),
+            handler: handler
+        )
+        subscriptions.append(subscriptionRecord)
+        
+        if socket?.readyState == .OPEN{
+            sendOperationAsync(.Subscribe(requestId: subscriptionRecord.requestId, query: query))
+        } else if socket == nil || socket?.readyState != .CONNECTING{
             if !userDisconnected{
                 reconnect()
             }else{
                 print("Warning: The client was explicitly disconnected! You must explicitly call .reconnect() in order to process your subscriptions.")
             }
-            
-        } else if socket?.readyState == .OPEN{
-            
-            sendOperationAsync(.Subscribe(requestId: subscriptionRecord.requestId, query: query))
         }
-
-            return handler
+        
+        return handler
     }
-
+    
     /**
      Unsubscribes all current subscriptions for a given query.
-
+     
      - parameter query: The query to unsubscribe from.
      */
     @objc(unsubscribeFromQuery:)
     public func unsubscribe(query: PFQuery) {
         unsubscribe { $0.query == query }
     }
-
+    
     /**
      Unsubscribes from a specific query-handler pair.
-
+     
      - parameter query:   The query to unsubscribe from.
      - parameter handler: The specific handler to unsubscribe from.
      */
     public func unsubscribe<T where T: SubscriptionHandling>(query: PFQuery, handler: T) {
         unsubscribe { $0.query == query && $0.subscriptionHandler === handler }
     }
-
+    
     func unsubscribe(@noescape matching matcher: SubscriptionRecord -> Bool) {
         subscriptions.filter {
             matcher($0)
-        }.forEach {
-            sendOperationAsync(.Unsubscribe(requestId: $0.requestId))
+            }.forEach {
+                sendOperationAsync(.Unsubscribe(requestId: $0.requestId))
         }
     }
     
@@ -199,7 +196,7 @@ extension Client {
 extension Client {
     /**
      Reconnects this client to the server.
-
+     
      This will disconnect and resubscribe all existing subscriptions. This is not required to be called the first time
      you use the client, and should usually only be called when an error occurs.
      */
@@ -210,14 +207,14 @@ extension Client {
             socket.delegate = self
             socket.setDelegateDispatchQueue(queue)
             socket.open()
-            userDisconnected = true
+            userDisconnected = false
             return socket
             }()
     }
-
+    
     /**
      Explicitly disconnects this client from the server.
-
+     
      This does not remove any subscriptions - if you `reconnect()` your existing subscriptions will be restored.
      Use this if you wish to dispose of the live query client.
      */

--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -174,7 +174,7 @@ extension Client {
 
     /**
      Unsubscribes from a specific query-handler pair.
-     
+
      - parameter query:   The query to unsubscribe from.
      - parameter handler: The specific handler to unsubscribe from.
      */

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -130,6 +130,7 @@ extension Client: SRWebSocketDelegate {
         // TODO: Add support for session token and user authetication.
         self.sendOperationAsync(.Connect(applicationId: applicationId, sessionToken: ""))
         disconnected = false
+        reconnecting = false
     }
 
     public func webSocket(webSocket: SRWebSocket!, didFailWithError error: NSError!) {

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -133,7 +133,7 @@ extension Client: SRWebSocketDelegate {
 
     public func webSocket(webSocket: SRWebSocket!, didFailWithError error: NSError!) {
         print("Error: \(error)")
-        
+
         if !userDisconnected {
             reconnect()
         }
@@ -141,7 +141,7 @@ extension Client: SRWebSocketDelegate {
 
     public func webSocket(webSocket: SRWebSocket!, didCloseWithCode code: Int, reason: String!, wasClean: Bool) {
         print("code: \(code) reason: \(reason)")
-        
+
         // TODO: Better retry logic, unless `disconnect()` was explicitly called
         if !userDisconnected {
             reconnect()

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -129,23 +129,25 @@ extension Client: SRWebSocketDelegate {
     public func webSocketDidOpen(webSocket: SRWebSocket!) {
         // TODO: Add support for session token and user authetication.
         self.sendOperationAsync(.Connect(applicationId: applicationId, sessionToken: ""))
+        disconnected = false
     }
 
     public func webSocket(webSocket: SRWebSocket!, didFailWithError error: NSError!) {
         print("Error: \(error)")
-
-        if !disconnected {
-            reconnect()
-        }
+        //set disconnect and try reconnecting
+        disconnected = true
+        reconnect()
     }
 
     public func webSocket(webSocket: SRWebSocket!, didCloseWithCode code: Int, reason: String!, wasClean: Bool) {
         print("code: \(code) reason: \(reason)")
 
-        // TODO: Better retry logic, unless `disconnect()` was explicitly called
-        if !disconnected {
-            reconnect()
-        }
+        
+        //set disconnect and try reconnecting on error
+        disconnected = true
+        reconnect()
+        
+        // TODO: Find better logic to handle user disconnect
     }
 
     public func webSocket(webSocket: SRWebSocket!, didReceiveMessage message: AnyObject?) {

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -133,6 +133,7 @@ extension Client: SRWebSocketDelegate {
 
     public func webSocket(webSocket: SRWebSocket!, didFailWithError error: NSError!) {
         print("Error: \(error)")
+        
         if !userDisconnected{
             reconnect()
         }
@@ -140,6 +141,7 @@ extension Client: SRWebSocketDelegate {
 
     public func webSocket(webSocket: SRWebSocket!, didCloseWithCode code: Int, reason: String!, wasClean: Bool) {
         print("code: \(code) reason: \(reason)")
+        
         // TODO: Better retry logic, unless `disconnect()` was explicitly called
         if !userDisconnected{
             reconnect()

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -19,9 +19,9 @@ private func parseObject<T: PFObject>(objectDictionary: [String:AnyObject]) thro
     guard let objectId = objectDictionary["objectId"] as? String else {
         throw LiveQueryErrors.InvalidJSONError(json: objectDictionary, expectedKey: "objectId")
     }
-    
+
     let parseObject = T(withoutDataWithClassName: parseClassName, objectId: objectId)
-    
+
     // Map of strings to closures to determine if the key is valid. Allows for more advanced checking of
     // classnames and such.
     let invalidKeys: [String:Void->Bool] = [
@@ -29,11 +29,11 @@ private func parseObject<T: PFObject>(objectDictionary: [String:AnyObject]) thro
         "parseClassName": { true },
         "sessionToken": { parseClassName == "_User" }
     ]
-    
+
     objectDictionary.filter { key, _ in
         return !(invalidKeys[key].map { $0() } ?? false)
-        }.forEach { key, value in
-            parseObject[key] = value
+    }.forEach { key, value in
+        parseObject[key] = value
     }
     return parseObject
 }
@@ -45,7 +45,7 @@ private func parseObject<T: PFObject>(objectDictionary: [String:AnyObject]) thro
 extension Client {
     class SubscriptionRecord {
         weak var subscriptionHandler: AnyObject?
-        
+
         // HandlerClosure captures the generic type info passed into the constructor of SubscriptionRecord,
         // and 'unwraps' it so that it can be used with just a 'PFObject' instance.
         // Technically, this should be a compiler no-op, as no witness tables should be used as 'PFObject' currently inherits from NSObject.
@@ -55,62 +55,62 @@ extension Client {
         var errorHandlerClosure: (ErrorType, Client) -> Void
         var subscribeHandlerClosure: Client -> Void
         var unsubscribeHandlerClosure: Client -> Void
-        
+
         let query: PFQuery
         let requestId: RequestId
-        
+
         init<T: SubscriptionHandling>(query: PFQuery, requestId: RequestId, handler: T) {
             self.query = query
             self.requestId = requestId
-            
+
             subscriptionHandler = handler
-            
+
             // This is needed because swift requires 'handlerClosure' to be fully initialized before we setup the
             // capture list for the closure.
             eventHandlerClosure = { _, _ in }
             errorHandlerClosure = { _, _ in }
             subscribeHandlerClosure = { _ in }
             unsubscribeHandlerClosure = { _ in }
-            
+
             eventHandlerClosure = { [weak self] event, client in
                 guard let handler = self?.subscriptionHandler as? T else {
                     return
                 }
-                
+
                 handler.didReceive(Event(event: event), forQuery: query, inClient: client)
             }
-            
+
             errorHandlerClosure = { [weak self] error, client in
                 guard let handler = self?.subscriptionHandler as? T else {
                     return
                 }
-                
+
                 handler.didEncounter(error, forQuery: query, inClient: client)
             }
-            
+
             subscribeHandlerClosure = { [weak self] client in
                 guard let handler = self?.subscriptionHandler as? T else {
                     return
                 }
-                
+
                 handler.didSubscribe(toQuery: query, inClient: client)
             }
-            
+
             unsubscribeHandlerClosure = { [weak self] client in
                 guard let handler = self?.subscriptionHandler as? T else {
                     return
                 }
-                
+
                 handler.didUnsubscribe(fromQuery: query, inClient: client)
             }
         }
     }
-    
+
     // An opaque placeholder structed used to ensure that we type-safely create request IDs and don't shoot ourself in
     // the foot with array indexes.
     struct RequestId: Equatable {
         let value: Int
-        
+
         init(value: Int) {
             self.value = value
         }
@@ -129,22 +129,26 @@ extension Client: SRWebSocketDelegate {
     public func webSocketDidOpen(webSocket: SRWebSocket!) {
         // TODO: Add support for session token and user authetication.
         self.sendOperationAsync(.Connect(applicationId: applicationId, sessionToken: ""))
+        
     }
-    
+
     public func webSocket(webSocket: SRWebSocket!, didFailWithError error: NSError!) {
         print("Error: \(error)")
-        
-        reconnect()
+        //set disconnect and try reconnecting
+        if !userDisconnected{
+            reconnect()
+        }
     }
-    
+
     public func webSocket(webSocket: SRWebSocket!, didCloseWithCode code: Int, reason: String!, wasClean: Bool) {
         print("code: \(code) reason: \(reason)")
         
-        reconnect()
-        
-        // TODO: Find better logic to handle user disconnect
+        //set disconnect and try reconnecting on error
+        if !userDisconnected{
+            reconnect()
+        }
     }
-    
+
     public func webSocket(webSocket: SRWebSocket!, didReceiveMessage message: AnyObject?) {
         guard let messageString = message as? String else {
             fatalError("Socket got into inconsistent state and received \(message) instead.")
@@ -167,23 +171,23 @@ extension Event {
         case .Enter(let reqId, let object):
             requestId = reqId
             self = .Entered(try parseObject(object))
-            
+
         case .Leave(let reqId, let object):
             requestId = reqId
             self = .Left(try parseObject(object))
-            
+
         case .Create(let reqId, let object):
             requestId = reqId
             self = .Created(try parseObject(object))
-            
+
         case .Update(let reqId, let object):
             requestId = reqId
             self = .Updated(try parseObject(object))
-            
+
         case .Delete(let reqId, let object):
             requestId = reqId
             self = .Deleted(try parseObject(object))
-            
+
         default: fatalError("Invalid state reached")
         }
     }
@@ -197,20 +201,20 @@ extension Client {
             where record.subscriptionHandler != nil else {
                 return nil
         }
-        
+
         return record
     }
-    
+
     func sendOperationAsync(operation: ClientOperation) -> Task<Void> {
         return Task(.Queue(queue)) {
             let jsonEncoded = operation.JSONObjectRepresentation
             let jsonData = try NSJSONSerialization.dataWithJSONObject(jsonEncoded, options: NSJSONWritingOptions(rawValue: 0))
             let jsonString = String(data: jsonData, encoding: NSUTF8StringEncoding)
-            
+
             self.socket?.send(jsonString)
         }
     }
-    
+
     func handleOperationAsync(string: String) -> Task<Void> {
         return Task(.Queue(queue)) {
             guard
@@ -221,30 +225,30 @@ extension Client {
                 else {
                     throw LiveQueryErrors.InvalidResponseError(response: string)
             }
-            
+
             switch response {
             case .Connected:
                 self.subscriptions.forEach {
                     self.sendOperationAsync(.Subscribe(requestId: $0.requestId, query: $0.query))
                 }
-                
+
             case .Redirect:
                 // TODO: Handle redirect.
                 break
-                
+
             case .Subscribed(let requestId):
                 self.subscriptionRecord(requestId)?.subscribeHandlerClosure(self)
-                
+
             case .Unsubscribed(let requestId):
                 guard
                     let recordIndex = self.subscriptions.indexOf({ $0.requestId == requestId }),
                     let record: SubscriptionRecord = self.subscriptions[recordIndex] else {
                         break
                 }
-                
+
                 record.unsubscribeHandlerClosure(self)
                 self.subscriptions.removeAtIndex(recordIndex)
-                
+
             case .Create, .Delete, .Enter, .Leave, .Update:
                 guard
                     var requestId: RequestId = RequestId(value: 0),
@@ -253,9 +257,9 @@ extension Client {
                     else {
                         break
                 }
-                
+
                 record.eventHandlerClosure(event, self)
-                
+
             case .Error(let requestId, let code, let error, let reconnect):
                 let error = LiveQueryErrors.ServerReportedError(code: code, error: error, reconnect: reconnect)
                 if let requestId = requestId {

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -209,7 +209,7 @@ extension Client {
             let jsonEncoded = operation.JSONObjectRepresentation
             let jsonData = try NSJSONSerialization.dataWithJSONObject(jsonEncoded, options: NSJSONWritingOptions(rawValue: 0))
             let jsonString = String(data: jsonData, encoding: NSUTF8StringEncoding)
-            
+
             self.socket?.send(jsonString)
         }
     }

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -129,7 +129,6 @@ extension Client: SRWebSocketDelegate {
     public func webSocketDidOpen(webSocket: SRWebSocket!) {
         // TODO: Add support for session token and user authetication.
         self.sendOperationAsync(.Connect(applicationId: applicationId, sessionToken: ""))
-        
     }
 
     public func webSocket(webSocket: SRWebSocket!, didFailWithError error: NSError!) {

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -134,7 +134,7 @@ extension Client: SRWebSocketDelegate {
     public func webSocket(webSocket: SRWebSocket!, didFailWithError error: NSError!) {
         print("Error: \(error)")
         
-        if !userDisconnected{
+        if !userDisconnected {
             reconnect()
         }
     }
@@ -143,7 +143,7 @@ extension Client: SRWebSocketDelegate {
         print("code: \(code) reason: \(reason)")
         
         // TODO: Better retry logic, unless `disconnect()` was explicitly called
-        if !userDisconnected{
+        if !userDisconnected {
             reconnect()
         }
     }

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -133,7 +133,6 @@ extension Client: SRWebSocketDelegate {
 
     public func webSocket(webSocket: SRWebSocket!, didFailWithError error: NSError!) {
         print("Error: \(error)")
-        //set disconnect and try reconnecting
         if !userDisconnected{
             reconnect()
         }
@@ -141,8 +140,7 @@ extension Client: SRWebSocketDelegate {
 
     public func webSocket(webSocket: SRWebSocket!, didCloseWithCode code: Int, reason: String!, wasClean: Bool) {
         print("code: \(code) reason: \(reason)")
-        
-        //set disconnect and try reconnecting on error
+        // TODO: Better retry logic, unless `disconnect()` was explicitly called
         if !userDisconnected{
             reconnect()
         }

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -209,7 +209,7 @@ extension Client {
             let jsonEncoded = operation.JSONObjectRepresentation
             let jsonData = try NSJSONSerialization.dataWithJSONObject(jsonEncoded, options: NSJSONWritingOptions(rawValue: 0))
             let jsonString = String(data: jsonData, encoding: NSUTF8StringEncoding)
-
+            
             self.socket?.send(jsonString)
         }
     }


### PR DESCRIPTION
The issue I found is that multiple subscription request in quick succession would cause the socket to throw an error.  This primarily happens because when the first subscription calls reconnect the socket is no longer nil. When the second socket calls subscribe the function will skip to  `sendOperationAsync(.Subscribe(requestId: subscriptionRecord.requestId, query: query))`

The error is thrown because the socket isnt nil...yet has not been completely connected. The simple fix is creating and setting a boolean that is set during the initial check...and isnt set back to false till the reconnect has finished.

I also fixed a little logic concerning disconnected. In a few places it was a little confusing and in disconnect even contradicted itself.
