### PR TITLE
Make path construction no longer explicitly reference /LQ.

### DIFF
--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -51,7 +51,6 @@ public class Client: NSObject {
             fatalError("Server should be a valid URL.")
         }
         components.scheme = components.scheme == "https" ? "wss" : "ws"
-        components.path = "/LQ"
 
         // Simple incrementing generator - can't use ++, that operator is deprecated!
         var currentRequestId = 0


### PR DESCRIPTION
This hasn't been necessary for a long time with LiveQuery, and should
allow this to operate properly behind a reverse proxy or other scenarios
where precise path matters.

Fixes #33.
