### PR TITLE
Lock dependencies' versions and Bump Bolts-Swift to 1.2.0

### DIFF
--- a/Examples/LiveQueryDemo-ObjC.xcodeproj/project.pbxproj
+++ b/Examples/LiveQueryDemo-ObjC.xcodeproj/project.pbxproj
@@ -135,12 +135,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F509D5431CA9E597007B15B0 /* Build configuration list for PBXNativeTarget "LiveQueryDemo-ObjC" */;
 			buildPhases = (
-				87DA45B46CF98727F2E13351 /* 📦 Check Pods Manifest.lock */,
+				87DA45B46CF98727F2E13351 /* [CP] Check Pods Manifest.lock */,
 				F509D52E1CA9E597007B15B0 /* Sources */,
 				F509D52F1CA9E597007B15B0 /* Frameworks */,
 				F509D5301CA9E597007B15B0 /* Resources */,
-				EA41B3F790AE39BE08641EBB /* 📦 Embed Pods Frameworks */,
-				A8851B9B8AD727FB055366F2 /* 📦 Copy Pods Resources */,
+				EA41B3F790AE39BE08641EBB /* [CP] Embed Pods Frameworks */,
+				A8851B9B8AD727FB055366F2 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -218,14 +218,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		87DA45B46CF98727F2E13351 /* 📦 Check Pods Manifest.lock */ = {
+		87DA45B46CF98727F2E13351 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -233,14 +233,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		A8851B9B8AD727FB055366F2 /* 📦 Copy Pods Resources */ = {
+		A8851B9B8AD727FB055366F2 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -248,14 +248,14 @@
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-LiveQueryDemo-ObjC/Pods-LiveQueryDemo-ObjC-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		EA41B3F790AE39BE08641EBB /* 📦 Embed Pods Frameworks */ = {
+		EA41B3F790AE39BE08641EBB /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/LiveQueryDemo.xcodeproj/project.pbxproj
+++ b/Examples/LiveQueryDemo.xcodeproj/project.pbxproj
@@ -123,12 +123,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F509D5251CA9E4AE007B15B0 /* Build configuration list for PBXNativeTarget "LiveQueryDemo" */;
 			buildPhases = (
-				E6F699DDDA9E6B861F705AD5 /* 📦 Check Pods Manifest.lock */,
+				E6F699DDDA9E6B861F705AD5 /* [CP] Check Pods Manifest.lock */,
 				F509D5131CA9E4AE007B15B0 /* Sources */,
 				F509D5141CA9E4AE007B15B0 /* Frameworks */,
 				F509D5151CA9E4AE007B15B0 /* Resources */,
-				045C33FD1807E3932888A2F9 /* 📦 Embed Pods Frameworks */,
-				D9EF05A29B9F1AAC9B62408C /* 📦 Copy Pods Resources */,
+				045C33FD1807E3932888A2F9 /* [CP] Embed Pods Frameworks */,
+				D9EF05A29B9F1AAC9B62408C /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -206,14 +206,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		045C33FD1807E3932888A2F9 /* 📦 Embed Pods Frameworks */ = {
+		045C33FD1807E3932888A2F9 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -221,14 +221,14 @@
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-LiveQueryDemo/Pods-LiveQueryDemo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D9EF05A29B9F1AAC9B62408C /* 📦 Copy Pods Resources */ = {
+		D9EF05A29B9F1AAC9B62408C /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -236,14 +236,14 @@
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-LiveQueryDemo/Pods-LiveQueryDemo-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E6F699DDDA9E6B861F705AD5 /* 📦 Check Pods Manifest.lock */ = {
+		E6F699DDDA9E6B861F705AD5 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ParseLiveQuery.podspec
+++ b/ParseLiveQuery.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.module_name = 'ParseLiveQuery'
 
   s.dependency 'Parse', '~> 1.14.0'
-  s.dependency 'Bolts-Swift', '~> 1.1.0'
+  s.dependency 'Bolts-Swift', '~> 1.2.0'
   s.dependency 'SocketRocket', '~> 0.5.0'
 end

--- a/ParseLiveQuery.podspec
+++ b/ParseLiveQuery.podspec
@@ -5,18 +5,18 @@ Pod::Spec.new do |s|
   s.summary          = 'Allows for subscriptions to queries in conjunction with parse-server.'
   s.homepage         = 'https://github.com/ParsePlatform/parse-server'
   s.authors          = { 'Richard Ross' => 'richardross@fb.com', 'Nikita Lutsenko' => 'nlutsenko@me.com' }
-  
+
   s.source       = { :git => 'https://github.com/ParsePlatform/ParseLiveQuery-iOS-OSX.git', :tag => s.version.to_s }
 
   s.requires_arc = true
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
-  
+
   s.source_files = 'Sources/ParseLiveQuery/**/*.swift'
   s.module_name = 'ParseLiveQuery'
-  
-  s.dependency 'Parse'
-  s.dependency 'Bolts-Swift'
-  s.dependency 'SocketRocket'
+
+  s.dependency 'Parse', '~> 1.14.0'
+  s.dependency 'Bolts-Swift', '~> 1.1.0'
+  s.dependency 'SocketRocket', '~> 0.5.0'
 end

--- a/Podfile
+++ b/Podfile
@@ -6,7 +6,7 @@ workspace 'ParseLiveQuery.xcworkspace'
 
 def commonPods
     pod 'Parse', '~> 1.14.0'
-    pod 'Bolts-Swift', '~> 1.1.0'
+    pod 'Bolts-Swift', '~> 1.2.0'
     pod 'SocketRocket', '~> 0.5.0'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -4,34 +4,32 @@
 use_frameworks!
 workspace 'ParseLiveQuery.xcworkspace'
 
+def commonPods
+    pod 'Parse', '~> 1.14.0'
+    pod 'Bolts-Swift', '~> 1.1.0'
+    pod 'SocketRocket', '~> 0.5.0'
+end
+
 target 'ParseLiveQuery-OSX' do
   project 'Sources/ParseLiveQuery.xcodeproj'
   platform :osx, '10.9'
-  pod 'Parse'
-  pod 'Bolts-Swift'
-  pod 'SocketRocket'
+  commonPods
 end
 
 target 'ParseLiveQuery-iOS' do
   project 'Sources/ParseLiveQuery.xcodeproj'
   platform :ios, '8.0'
-  pod 'Parse'
-  pod 'Bolts-Swift'
-  pod 'SocketRocket'
+  commonPods
 end
 
 target 'LiveQueryDemo' do
   project 'Examples/LiveQueryDemo.xcodeproj'
   platform :osx, '10.9'
-  pod 'Parse'
-  pod 'Bolts-Swift'
-  pod 'SocketRocket'
+  commonPods
 end
 
 target 'LiveQueryDemo-ObjC' do
   project 'Examples/LiveQueryDemo-ObjC.xcodeproj'
   platform :osx, '10.9'
-  pod 'Parse'
-  pod 'Bolts-Swift'
-  pod 'SocketRocket'
+  commonPods
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
-  - Bolts-Swift (1.0.1)
-  - Bolts/Tasks (1.7.0)
-  - Parse (1.13.0):
-    - Bolts/Tasks (~> 1.6)
-  - SocketRocket (0.5.0)
+  - Bolts-Swift (1.1.0)
+  - Bolts/Tasks (1.8.4)
+  - Parse (1.14.2):
+    - Bolts/Tasks (~> 1.8)
+  - SocketRocket (0.5.1)
 
 DEPENDENCIES:
-  - Bolts-Swift
-  - Parse
-  - SocketRocket
+  - Bolts-Swift (~> 1.1.0)
+  - Parse (~> 1.14.0)
+  - SocketRocket (~> 0.5.0)
 
 SPEC CHECKSUMS:
-  Bolts: a0058fa3b331c5a1e4402d534f2dae36dbff31e4
-  Bolts-Swift: 1c4c4955b1aacfc83f6a1998f6ad9627c35f8c4f
-  Parse: f51c24d2feb412e4b2d6cc73d37cb24e8d0089bc
-  SocketRocket: 2c51efccd2d73c99a923407ca4b06e7e9da95dbf
+  Bolts: 8a7995239dbe724f9cba2248b766d48b7ebdd322
+  Bolts-Swift: 63ef77f967f795415531da45eef419eab79ec730
+  Parse: 4335d65f40cb3d43190d723144bbe1afb9c38230
+  SocketRocket: d57c7159b83c3c6655745cd15302aa24b6bae531
 
-PODFILE CHECKSUM: 8b4289d8be4dced36d3871d24ac231402f0c5dfd
+PODFILE CHECKSUM: fcd375be1a1538521d472bc102f51d2be8e421b7
 
-COCOAPODS: 1.0.0.beta.6
+COCOAPODS: 1.0.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
-  - Bolts-Swift (1.1.0)
+  - Bolts-Swift (1.2.0)
   - Bolts/Tasks (1.8.4)
   - Parse (1.14.2):
     - Bolts/Tasks (~> 1.8)
   - SocketRocket (0.5.1)
 
 DEPENDENCIES:
-  - Bolts-Swift (~> 1.1.0)
+  - Bolts-Swift (~> 1.2.0)
   - Parse (~> 1.14.0)
   - SocketRocket (~> 0.5.0)
 
 SPEC CHECKSUMS:
   Bolts: 8a7995239dbe724f9cba2248b766d48b7ebdd322
-  Bolts-Swift: 63ef77f967f795415531da45eef419eab79ec730
+  Bolts-Swift: ac4e7d26719ed0f73aa85b9310da1648105fbde3
   Parse: 4335d65f40cb3d43190d723144bbe1afb9c38230
   SocketRocket: d57c7159b83c3c6655745cd15302aa24b6bae531
 
-PODFILE CHECKSUM: fcd375be1a1538521d472bc102f51d2be8e421b7
+PODFILE CHECKSUM: 70b6aa76074351157d833d108d7802776bc8dcd4
 
 COCOAPODS: 1.0.1

--- a/Sources/ParseLiveQuery.xcodeproj/project.pbxproj
+++ b/Sources/ParseLiveQuery.xcodeproj/project.pbxproj
@@ -180,12 +180,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F5903CEF1BD999C500C3EFFE /* Build configuration list for PBXNativeTarget "ParseLiveQuery-OSX" */;
 			buildPhases = (
-				432EB76C64066D923373DC45 /* 📦 Check Pods Manifest.lock */,
+				432EB76C64066D923373DC45 /* [CP] Check Pods Manifest.lock */,
 				F5903CE51BD999C500C3EFFE /* Sources */,
 				F5903CE61BD999C500C3EFFE /* Frameworks */,
 				F5903CE71BD999C500C3EFFE /* Headers */,
 				F5903CE81BD999C500C3EFFE /* Resources */,
-				458C6F69E79D3F67465FC4DB /* 📦 Copy Pods Resources */,
+				458C6F69E79D3F67465FC4DB /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -200,12 +200,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F5A9BFC71BE0248D00E78326 /* Build configuration list for PBXNativeTarget "ParseLiveQuery-iOS" */;
 			buildPhases = (
-				0779A1A9A8C094A6EC98CD51 /* 📦 Check Pods Manifest.lock */,
+				0779A1A9A8C094A6EC98CD51 /* [CP] Check Pods Manifest.lock */,
 				F5A9BFBA1BE0248D00E78326 /* Sources */,
 				F5A9BFC01BE0248D00E78326 /* Frameworks */,
 				F5A9BFC31BE0248D00E78326 /* Headers */,
 				F5A9BFC51BE0248D00E78326 /* Resources */,
-				89E3C0C052352147C9B80227 /* 📦 Copy Pods Resources */,
+				89E3C0C052352147C9B80227 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -267,14 +267,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0779A1A9A8C094A6EC98CD51 /* 📦 Check Pods Manifest.lock */ = {
+		0779A1A9A8C094A6EC98CD51 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -282,14 +282,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		432EB76C64066D923373DC45 /* 📦 Check Pods Manifest.lock */ = {
+		432EB76C64066D923373DC45 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -297,14 +297,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		458C6F69E79D3F67465FC4DB /* 📦 Copy Pods Resources */ = {
+		458C6F69E79D3F67465FC4DB /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -312,14 +312,14 @@
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-ParseLiveQuery-OSX/Pods-ParseLiveQuery-OSX-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		89E3C0C052352147C9B80227 /* 📦 Copy Pods Resources */ = {
+		89E3C0C052352147C9B80227 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/ParseLiveQuery/Internal/BoltsHelpers.swift
+++ b/Sources/ParseLiveQuery/Internal/BoltsHelpers.swift
@@ -33,9 +33,9 @@ func swiftTask(task: BFTask) -> Task<AnyObject> {
         if task.cancelled {
             taskCompletionSource.tryCancel()
         } else if let error = task.error where task.faulted {
-            taskCompletionSource.trySetError(error)
+            taskCompletionSource.trySet(error: error)
         } else if let result = task.result {
-            taskCompletionSource.trySetResult(result)
+            taskCompletionSource.trySet(result: result)
         } else {
             fatalError("Unknown task state")
         }

--- a/Sources/ParseLiveQuery/Subscription.swift
+++ b/Sources/ParseLiveQuery/Subscription.swift
@@ -18,7 +18,7 @@ import BoltsSwift
  */
 public protocol SubscriptionHandling: AnyObject {
     /// The type of the PFObject subclass that this handler uses.
-    typealias PFObjectSubclass: PFObject
+    associatedtype PFObjectSubclass: PFObject
 
     /**
      Tells the handler that an event has been received from the live query server.


### PR DESCRIPTION
### Lock CocoaPods dependencies' versions

Until now, none of the dependencies had their version locked in either
the .podspec or Podfile. So, if one of them got updated with breaking
changes then building would ouviously break after a `pod update`.

This issue happened recently when Bolts-Swift was updated with breaking
changes from 1.1.0 to 1.2.0.

This addresses that by locking the dependency versions to the latest
compatible version at the moment. When support is added to the new
dependency versions, the podspec/Podfile should be updated and the pod
version should be bumped.
### Bump Bolts-Swift to 1.2.0
- Updated Bolts-Swift to 1.2.0 in the .podspec and Podfile
- Updated BoltsHelpers.swift to use the new `TaskCompletionSource` API
- Fixed warning for using `typealias` when `associatedtype` should be
  used
