### PR TITLE
Added support for session token and user authentication.

### DIFF
--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -151,7 +151,8 @@ extension Client {
         subscriptions.append(subscriptionRecord)
         
         if socket?.readyState == .OPEN {
-            _ = sendOperationAsync(.subscribe(requestId: subscriptionRecord.requestId, query: query as! PFQuery<PFObject>))
+            _ = sendOperationAsync(.subscribe(requestId: subscriptionRecord.requestId, query: query as! PFQuery<PFObject>,
+            sessionToken: PFUser.currentUser()?.sessionToken))
         } else if socket == nil || socket?.readyState != .CONNECTING {
             if !userDisconnected {
                 reconnect()

--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -152,7 +152,7 @@ extension Client {
         
         if socket?.readyState == .OPEN {
             _ = sendOperationAsync(.subscribe(requestId: subscriptionRecord.requestId, query: query as! PFQuery<PFObject>,
-            sessionToken: PFUser.currentUser()?.sessionToken))
+            sessionToken: PFUser.current()?.sessionToken))
         } else if socket == nil || socket?.readyState != .CONNECTING {
             if !userDisconnected {
                 reconnect()

--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -23,7 +23,7 @@ open class Client: NSObject {
     let clientKey: String?
 
     var socket: SRWebSocket?
-    var userDisconnected = false
+    public var userDisconnected = false
 
     // This allows us to easily plug in another request ID generation scheme, or more easily change the request id type
     // if needed (technically this could be a string).

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -139,7 +139,7 @@ extension Client: SRWebSocketDelegate {
 
     public func webSocketDidOpen(_ webSocket: SRWebSocket!) {
         // TODO: Add support for session token and user authetication.
-        _ = self.sendOperationAsync(.connect(applicationId: applicationId, sessionToken: ""))
+        _ = self.sendOperationAsync(.connect(applicationId: applicationId, sessionToken: PFUser.currentUser()?.sessionToken))
     }
 
     public func webSocket(_ webSocket: SRWebSocket!, didFailWithError error: Error!) {
@@ -227,8 +227,9 @@ extension Client {
 
             switch response {
             case .connected:
+                let sessionToken = PFUser.currentUser()?.sessionToken
                 self.subscriptions.forEach {
-                    _ = self.sendOperationAsync(.subscribe(requestId: $0.requestId, query: $0.query))
+                    _ = self.sendOperationAsync(.subscribe(requestId: $0.requestId, query: $0.query, sessionToken: sessionToken))
                 }
 
             case .redirect:

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -138,8 +138,8 @@ extension Client: SRWebSocketDelegate {
     }
 
     public func webSocketDidOpen(_ webSocket: SRWebSocket!) {
-        // TODO: Add support for session token and user authetication.
-        _ = self.sendOperationAsync(.connect(applicationId: applicationId, sessionToken: PFUser.currentUser()?.sessionToken))
+        let sessionToken = PFUser.current()?.sessionToken ?? ""
+        _ = self.sendOperationAsync(.connect(applicationId: applicationId, sessionToken: sessionToken))
     }
 
     public func webSocket(_ webSocket: SRWebSocket!, didFailWithError error: Error!) {
@@ -227,7 +227,7 @@ extension Client {
 
             switch response {
             case .connected:
-                let sessionToken = PFUser.currentUser()?.sessionToken
+                let sessionToken = PFUser.current()?.sessionToken
                 self.subscriptions.forEach {
                     _ = self.sendOperationAsync(.subscribe(requestId: $0.requestId, query: $0.query, sessionToken: sessionToken))
                 }

--- a/Sources/ParseLiveQuery/Internal/Operation.swift
+++ b/Sources/ParseLiveQuery/Internal/Operation.swift
@@ -12,16 +12,21 @@ import Parse
 
 enum ClientOperation {
     case connect(applicationId: String, sessionToken: String)
-    case subscribe(requestId: Client.RequestId, query: PFQuery<PFObject>)
+    case subscribe(requestId: Client.RequestId, query: PFQuery<PFObject>, sessionToken: String?)
     case unsubscribe(requestId: Client.RequestId)
 
     var JSONObjectRepresentation: [String : Any] {
         switch self {
         case .connect(let applicationId, let sessionToken):
+            var result: [String: Any] = [ "op": "connect", "applicationId": applicationId ]
             return [ "op": "connect", "applicationId": applicationId, "sessionToken": sessionToken ]
+            if let sessionToken = sessionToken {
+                result["sessionToken"] = sessionToken
+            }
+            return result
 
-        case .subscribe(let requestId, let query):
-            return [ "op": "subscribe", "requestId": requestId.value, "query": Dictionary<String, AnyObject>(query: query) ]
+        case .subscribe(let requestId, let query, let sessionToken):
+            return [ "op": "subscribe", "requestId": requestId.value, "query": Dictionary<String, AnyObject>(query: query), "sessionToken": sessionToken ]
 
         case .unsubscribe(let requestId):
             return [ "op": "unsubscribe", "requestId": requestId.value ]

--- a/Sources/ParseLiveQuery/Internal/Operation.swift
+++ b/Sources/ParseLiveQuery/Internal/Operation.swift
@@ -18,15 +18,14 @@ enum ClientOperation {
     var JSONObjectRepresentation: [String : Any] {
         switch self {
         case .connect(let applicationId, let sessionToken):
-            var result: [String: Any] = [ "op": "connect", "applicationId": applicationId ]
             return [ "op": "connect", "applicationId": applicationId, "sessionToken": sessionToken ]
+
+        case .subscribe(let requestId, let query, let sessionToken):
+            var result: [String: Any] =  [ "op": "subscribe", "requestId": requestId.value, "query": Dictionary<String, AnyObject>(query: query) ]
             if let sessionToken = sessionToken {
                 result["sessionToken"] = sessionToken
             }
             return result
-
-        case .subscribe(let requestId, let query, let sessionToken):
-            return [ "op": "subscribe", "requestId": requestId.value, "query": Dictionary<String, AnyObject>(query: query), "sessionToken": sessionToken ]
 
         case .unsubscribe(let requestId):
             return [ "op": "unsubscribe", "requestId": requestId.value ]


### PR DESCRIPTION
Added using of `sessionToken` for both Connect and Subscribe messages. sessionToken is taken from PFUser.currentUser() directly and passes only if it's not nil.

Tested, works fine for me.
