### PR TITLE
Live query update

### DIFF
--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -184,6 +184,7 @@ extension Client {
         matching matcher: @escaping (SubscriptionRecord) -> Bool
         ) where T: PFObject {
         subscriptions(matching: matcher).forEach {
+            $0.query = query as! PFQuery<PFObject>
             _ = sendOperationAsync(.update(requestId: $0.requestId, query: query as! PFQuery<PFObject>))
         }
     }

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -55,7 +55,7 @@ extension Client {
         var subscribeHandlerClosure: (Client) -> Void
         var unsubscribeHandlerClosure: (Client) -> Void
 
-        let query: PFQuery<PFObject>
+        var query: PFQuery<PFObject>
         let requestId: RequestId
 
         init<T>(query: PFQuery<T.PFObjectSubclass>, requestId: RequestId, handler: T) where T:SubscriptionHandling {

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -55,7 +55,7 @@ extension Client {
         var subscribeHandlerClosure: (Client) -> Void
         var unsubscribeHandlerClosure: (Client) -> Void
 
-        var query: PFQuery<PFObject>
+        let query: PFQuery<PFObject>
         let requestId: RequestId
 
         init<T>(query: PFQuery<T.PFObjectSubclass>, requestId: RequestId, handler: T) where T:SubscriptionHandling {

--- a/Sources/ParseLiveQuery/Internal/Operation.swift
+++ b/Sources/ParseLiveQuery/Internal/Operation.swift
@@ -13,6 +13,7 @@ import Parse
 enum ClientOperation {
     case connect(applicationId: String, sessionToken: String)
     case subscribe(requestId: Client.RequestId, query: PFQuery<PFObject>)
+    case update(requestId: Client.RequestId, query: PFQuery<PFObject>)
     case unsubscribe(requestId: Client.RequestId)
 
     var JSONObjectRepresentation: [String : Any] {
@@ -22,6 +23,9 @@ enum ClientOperation {
 
         case .subscribe(let requestId, let query):
             return [ "op": "subscribe", "requestId": requestId.value, "query": Dictionary<String, AnyObject>(query: query) ]
+
+        case .update(let requestId, let query):
+            return [ "op": "update", "requestId": requestId.value, "query": Dictionary<String, AnyObject>(query: query) ]
 
         case .unsubscribe(let requestId):
             return [ "op": "unsubscribe", "requestId": requestId.value ]


### PR DESCRIPTION
Update to the SDK to allow liveQueryClients to update the subscriptions without going round-trip remove/subscribe

https://github.com/ParsePlatform/parse-server/pull/2935
