### PR TITLE
Add support for using Parse's native object encoding

### DIFF
--- a/Sources/ParseLiveQuery.xcodeproj/project.pbxproj
+++ b/Sources/ParseLiveQuery.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		0632EDD41CA1A6DB00DD3CB8 /* Parse+LiveQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0632EDD31CA1A6DB00DD3CB8 /* Parse+LiveQuery.swift */; };
 		0632EDD51CA1A6DB00DD3CB8 /* Parse+LiveQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0632EDD31CA1A6DB00DD3CB8 /* Parse+LiveQuery.swift */; };
+		3B68E5B71DECC32300038DDD /* PFEncoder_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B68E5B61DECC32300038DDD /* PFEncoder_internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3B68E5B81DECC32300038DDD /* PFEncoder_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B68E5B61DECC32300038DDD /* PFEncoder_internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4A819D9D1D937866009C0F61 /* ObjCCompat.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54D58B51C8E33D9009F8D6C /* ObjCCompat.swift */; };
 		4A819D9E1D93786A009C0F61 /* ObjCCompat.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54D58B51C8E33D9009F8D6C /* ObjCCompat.swift */; };
 		4AEAE5761DAFC808005F9FFB /* PFDecoder_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AEAE5701DAFC3AF005F9FFB /* PFDecoder_internal.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -38,6 +40,7 @@
 /* Begin PBXFileReference section */
 		0632EDD31CA1A6DB00DD3CB8 /* Parse+LiveQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Parse+LiveQuery.swift"; sourceTree = "<group>"; };
 		11F6DFE2732DB0DE49976BA5 /* Pods-ParseLiveQuery OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ParseLiveQuery OSX.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ParseLiveQuery OSX/Pods-ParseLiveQuery OSX.release.xcconfig"; sourceTree = "<group>"; };
+		3B68E5B61DECC32300038DDD /* PFEncoder_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFEncoder_internal.h; sourceTree = "<group>"; };
 		4AEAE5701DAFC3AF005F9FFB /* PFDecoder_internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PFDecoder_internal.h; sourceTree = "<group>"; };
 		4AEAE5731DAFC488005F9FFB /* ParseLiveQuery-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ParseLiveQuery-Bridging-Header.h"; sourceTree = "<group>"; };
 		6062D7994653A4F07D1358B9 /* Pods-ParseLiveQuery iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ParseLiveQuery iOS.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-ParseLiveQuery iOS/Pods-ParseLiveQuery iOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -159,6 +162,7 @@
 				F54D58B71C8E3446009F8D6C /* ClientPrivate.swift */,
 				F54D58B91C8E345F009F8D6C /* BoltsHelpers.swift */,
 				4AEAE5701DAFC3AF005F9FFB /* PFDecoder_internal.h */,
+				3B68E5B61DECC32300038DDD /* PFEncoder_internal.h */,
 				4AEAE5731DAFC488005F9FFB /* ParseLiveQuery-Bridging-Header.h */,
 			);
 			path = Internal;
@@ -173,6 +177,7 @@
 			files = (
 				4AEAE5791DAFC809005F9FFB /* ParseLiveQuery-Bridging-Header.h in Headers */,
 				4AEAE5781DAFC809005F9FFB /* PFDecoder_internal.h in Headers */,
+				3B68E5B81DECC32300038DDD /* PFEncoder_internal.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -182,6 +187,7 @@
 			files = (
 				4AEAE5771DAFC808005F9FFB /* ParseLiveQuery-Bridging-Header.h in Headers */,
 				4AEAE5761DAFC808005F9FFB /* PFDecoder_internal.h in Headers */,
+				3B68E5B71DECC32300038DDD /* PFEncoder_internal.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/ParseLiveQuery/Internal/PFEncoder_internal.h
+++ b/Sources/ParseLiveQuery/Internal/PFEncoder_internal.h
@@ -1,0 +1,46 @@
+//
+//  PFEncoder_internal.h
+//  ParseLiveQuery
+//
+//  Created by Joe Szymanski on 11/28/16.
+//  Copyright © 2016 Parse. All rights reserved.
+//
+
+#ifndef PFEncoder_internal_h
+#define PFEncoder_internal_h
+
+#import <Foundation/Foundation.h>
+#import <Parse/PFObject.h>
+
+@interface PFEncoder : NSObject
+
++ (nonnull instancetype)objectEncoder;
+
+- (nullable id)encodeObject:(nullable id)object;
+- (nullable id)encodeParseObject:(nullable PFObject *)object;
+
+@end
+
+/**
+ Encoding strategy that rejects PFObject.
+ */
+@interface PFNoObjectEncoder : PFEncoder
+
+@end
+
+/**
+ Encoding strategy that encodes PFObject to PFPointer with objectId or with localId.
+ */
+@interface PFPointerOrLocalIdObjectEncoder : PFEncoder
+
+@end
+
+/**
+ Encoding strategy that encodes PFObject to PFPointer with objectId and rejects
+ unsaved PFObject.
+ */
+@interface PFPointerObjectEncoder : PFPointerOrLocalIdObjectEncoder
+
+@end
+
+#endif /* PFEncoder_internal_h */

--- a/Sources/ParseLiveQuery/Internal/ParseLiveQuery-Bridging-Header.h
+++ b/Sources/ParseLiveQuery/Internal/ParseLiveQuery-Bridging-Header.h
@@ -7,3 +7,4 @@
 //
 
 #import "PFDecoder_internal.h"
+#import "PFEncoder_internal.h"

--- a/Sources/ParseLiveQuery/Internal/QueryEncoder.swift
+++ b/Sources/ParseLiveQuery/Internal/QueryEncoder.swift
@@ -34,6 +34,8 @@ extension Dictionary where Key: ExpressibleByStringLiteral, Value: AnyObject {
                 encodedQueryDictionary[key] = dict.encodedQueryDictionary as? Value
             } else if let geoPoint = val as? PFGeoPoint {
                 encodedQueryDictionary[key] = geoPoint.encodedDictionary as? Value
+            } else if let object = val as? PFObject {
+                encodedQueryDictionary[key] = PFPointerObjectEncoder.object().encode(object) as? Value
             } else {
                 encodedQueryDictionary[key] = val
             }


### PR DESCRIPTION
Create private headers to access the PFEncoder classes. Update the
encoding of queries into dictionaries to properly use Parse's encoder
for any PFObject subclasses.