### PR TITLE
Add a property "shouldPrintWebSocketLog" for Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ subscription.handle(Event.Created) { query, object in
 }
 ```
 
+By default, it will print the logs from WebSocket / WebSocketDelegate. You can turn it off:
+```swift
+Client.shared.shouldPrintWebSocketLog = false
+```
+
 Handling errors is and other events is similar, take a look at the `Subscription` class for more information.
 
 ## Advanced Usage
@@ -65,7 +70,7 @@ We want to make contributing to this project as easy and transparent as possible
 
 -----
 
-As of April 5, 2017, Parse, LLC has transferred this code to the parse-community organization, and will no longer be contributing to or distributing this code. 
+As of April 5, 2017, Parse, LLC has transferred this code to the parse-community organization, and will no longer be contributing to or distributing this code.
 
  [releases]: https://github.com/parse-community/ParseLiveQuery-iOS-OSX/releases
  [contributing]: https://github.com/parse-community/ParseLiveQuery-iOS-OSX/blob/master/CONTRIBUTING.md
@@ -87,4 +92,3 @@ As of April 5, 2017, Parse, LLC has transferred this code to the parse-community
 
  [carthage-svg]:https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat
  [carthage-link]:https://github.com/Carthage/Carthage
-

--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -23,7 +23,7 @@ open class Client: NSObject {
     let clientKey: String?
 
     var socket: WebSocket?
-    var shouldPrintWebSocketLog = false
+    var shouldPrintWebSocketLog = true
     public var userDisconnected = false
 
     // This allows us to easily plug in another request ID generation scheme, or more easily change the request id type

--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -23,7 +23,7 @@ open class Client: NSObject {
     let clientKey: String?
 
     var socket: WebSocket?
-    var shouldPrintWebSocketLog = true
+    public var shouldPrintWebSocketLog = true
     public var userDisconnected = false
 
     // This allows us to easily plug in another request ID generation scheme, or more easily change the request id type

--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -23,6 +23,7 @@ open class Client: NSObject {
     let clientKey: String?
 
     var socket: WebSocket?
+    var shouldPrintWebSocketLog = false
     public var userDisconnected = false
 
     // This allows us to easily plug in another request ID generation scheme, or more easily change the request id type

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -121,8 +121,8 @@ extension Client: WebSocketDelegate {
     }
 
     public func websocketDidReceiveMessage(socket: WebSocket, text: String) {
-        handleOperationAsync(text).continueWith { task in
-            if let error = task.error, shouldPrintWebSocketLog {
+        handleOperationAsync(text).continueWith { [weak self] task in
+            if let error = task.error, self?.shouldPrintWebSocketLog == true {
                 print("Error: \(error)")
             }
         }

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -117,12 +117,12 @@ func == (first: Client.RequestId, second: Client.RequestId) -> Bool {
 extension Client: WebSocketDelegate {
 
     public func websocketDidReceiveData(socket: WebSocket, data: Data) {
-        print("Received binary data but we don't handle it...")
+        if shouldPrintWebSocketLog { print("Received binary data but we don't handle it...") }
     }
 
     public func websocketDidReceiveMessage(socket: WebSocket, text: String) {
         handleOperationAsync(text).continueWith { task in
-            if let error = task.error {
+            if let error = task.error, shouldPrintWebSocketLog {
                 print("Error: \(error)")
             }
         }
@@ -134,7 +134,7 @@ extension Client: WebSocketDelegate {
     }
 
     public func websocketDidDisconnect(socket: WebSocket, error: NSError?) {
-        print("error: \(error)")
+        if shouldPrintWebSocketLog { print("error: \(String(describing: error))") }
 
         // TODO: Better retry logic, unless `disconnect()` was explicitly called
         if !userDisconnected {
@@ -143,7 +143,7 @@ extension Client: WebSocketDelegate {
     }
 
     public func webSocket(_ webSocket: WebSocket, didCloseWithCode code: Int, reason: String?, wasClean: Bool) {
-        print("code: \(code) reason: \(reason)")
+        if shouldPrintWebSocketLog { print("code: \(code) reason: \(String(describing: reason))") }
 
         // TODO: Better retry logic, unless `disconnect()` was explicitly called
         if !userDisconnected {


### PR DESCRIPTION
If the device disconnected from the WebSocket, the delegate will trigger **func websocketDidDisconnect(socket:error:)**, and print lots of logs by:
`print("error: \(error)")`

It is not ideal for release build, so this pull request adds a property **"shouldPrintWebSocketLog" for class Client.** By default this value is true, and you can turn the logs off by setting it false.