### PR TITLE
Including clientKey in connect operation per specifications.

### DIFF
--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -130,7 +130,7 @@ extension Client: WebSocketDelegate {
 
     public func websocketDidConnect(socket: WebSocket) {
         let sessionToken = PFUser.current()?.sessionToken ?? ""
-        _ = self.sendOperationAsync(.connect(applicationId: applicationId, sessionToken: sessionToken))
+        _ = self.sendOperationAsync(.connect(applicationId: applicationId, sessionToken: sessionToken, clientKey: clientKey))
     }
 
     public func websocketDidDisconnect(socket: WebSocket, error: NSError?) {

--- a/Sources/ParseLiveQuery/Internal/Operation.swift
+++ b/Sources/ParseLiveQuery/Internal/Operation.swift
@@ -19,7 +19,7 @@ enum ClientOperation {
     var JSONObjectRepresentation: [String : Any] {
         switch self {
         case .connect(let applicationId, let sessionToken, let clientKey):
-            return [ "op": "connect", "applicationId": applicationId, "sessionToken": sessionToken, clientKey: clientKey ]
+            return [ "op": "connect", "applicationId": applicationId, "sessionToken": sessionToken, "clientKey" : clientKey ]
 
         case .subscribe(let requestId, let query, let sessionToken):
             var result: [String: Any] =  [ "op": "subscribe", "requestId": requestId.value, "query": Dictionary<String, AnyObject>(query: query) ]

--- a/Sources/ParseLiveQuery/Internal/Operation.swift
+++ b/Sources/ParseLiveQuery/Internal/Operation.swift
@@ -11,15 +11,15 @@ import Foundation
 import Parse
 
 enum ClientOperation {
-    case connect(applicationId: String, sessionToken: String)
+    case connect(applicationId: String, sessionToken: String, clientKey: String?)
     case subscribe(requestId: Client.RequestId, query: PFQuery<PFObject>, sessionToken: String?)
     case update(requestId: Client.RequestId, query: PFQuery<PFObject>)
     case unsubscribe(requestId: Client.RequestId)
 
     var JSONObjectRepresentation: [String : Any] {
         switch self {
-        case .connect(let applicationId, let sessionToken):
-            return [ "op": "connect", "applicationId": applicationId, "sessionToken": sessionToken ]
+        case .connect(let applicationId, let sessionToken, let clientKey):
+            return [ "op": "connect", "applicationId": applicationId, "sessionToken": sessionToken, clientKey: clientKey ]
 
         case .subscribe(let requestId, let query, let sessionToken):
             var result: [String: Any] =  [ "op": "subscribe", "requestId": requestId.value, "query": Dictionary<String, AnyObject>(query: query) ]

--- a/Sources/ParseLiveQuery/Internal/Operation.swift
+++ b/Sources/ParseLiveQuery/Internal/Operation.swift
@@ -19,7 +19,7 @@ enum ClientOperation {
     var JSONObjectRepresentation: [String : Any] {
         switch self {
         case .connect(let applicationId, let sessionToken, let clientKey):
-            return [ "op": "connect", "applicationId": applicationId, "sessionToken": sessionToken, "clientKey" : clientKey ]
+            return [ "op": "connect", "applicationId": applicationId, "sessionToken": sessionToken, "clientKey": clientKey ]
 
         case .subscribe(let requestId, let query, let sessionToken):
             var result: [String: Any] =  [ "op": "subscribe", "requestId": requestId.value, "query": Dictionary<String, AnyObject>(query: query) ]


### PR DESCRIPTION
This merge is to uphold the specifications regarding servers that initialize Live Query with key pairs.