### PR TITLE
Update logging for WebSockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ By default, it will print the logs from WebSocket / WebSocketDelegate. You can t
 Client.shared.shouldPrintWebSocketLog = false
 ```
 
+You can also enable socket trace messages for all sent and received strings. By default, these trace messages are disabled.
+```swift
+Client.shared.shouldPrintWebSocketTrace = true
+```
+
 Handling errors is and other events is similar, take a look at the `Subscription` class for more information.
 
 ## Advanced Usage

--- a/Sources/ParseLiveQuery/Client.swift
+++ b/Sources/ParseLiveQuery/Client.swift
@@ -24,6 +24,7 @@ open class Client: NSObject {
 
     var socket: WebSocket?
     public var shouldPrintWebSocketLog = true
+    public var shouldPrintWebSocketTrace = false
     public var userDisconnected = false
 
     // This allows us to easily plug in another request ID generation scheme, or more easily change the request id type
@@ -158,7 +159,7 @@ extension Client {
             if !userDisconnected {
                 reconnect()
             } else {
-                debugPrint("Warning: The client was explicitly disconnected! You must explicitly call .reconnect() in order to process your subscriptions.")
+                NSLog("ParseLiveQuery: Warning: The client was explicitly disconnected! You must explicitly call .reconnect() in order to process your subscriptions.")
             }
         }
         

--- a/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
+++ b/Sources/ParseLiveQuery/Internal/ClientPrivate.swift
@@ -123,7 +123,7 @@ extension Client: WebSocketDelegate {
     public func websocketDidReceiveMessage(socket: WebSocket, text: String) {
         handleOperationAsync(text).continueWith { [weak self] task in
             if let error = task.error, self?.shouldPrintWebSocketLog == true {
-                if shouldPrintWebSocketLog { NSLog("ParseLiveQuery: Error processing message: \(error)") }
+                NSLog("ParseLiveQuery: Error processing message: \(error)")
             }
         }
     }
@@ -199,14 +199,14 @@ extension Client {
             let jsonEncoded = operation.JSONObjectRepresentation
             let jsonData = try JSONSerialization.data(withJSONObject: jsonEncoded, options: JSONSerialization.WritingOptions(rawValue: 0))
             let jsonString = String(data: jsonData, encoding: String.Encoding.utf8)
-            if shouldPrintWebSocketTrace { NSLog("ParseLiveQuery: Sending message: \(jsonString!)") }
+            if self.shouldPrintWebSocketTrace { NSLog("ParseLiveQuery: Sending message: \(jsonString!)") }
             self.socket?.write(string: jsonString!)
         }
     }
 
     func handleOperationAsync(_ string: String) -> Task<Void> {
         return Task(.queue(queue)) {
-            if shouldPrintWebSocketTrace { NSLog("ParseLiveQuery: Received message: \(jsonString!)") }
+            if self.shouldPrintWebSocketTrace { NSLog("ParseLiveQuery: Received message: \(string)") }
             guard
                 let jsonData = string.data(using: String.Encoding.utf8),
                 let jsonDecoded = try JSONSerialization.jsonObject(with: jsonData, options: JSONSerialization.ReadingOptions(rawValue: 0))
@@ -215,8 +215,6 @@ extension Client {
                 else {
                     throw LiveQueryErrors.InvalidResponseError(response: string)
             }
-
-
 
             switch response {
             case .connected:


### PR DESCRIPTION
* Convert all logs from print()/debugPrint() to NSLog() to support
debugging on devices
* Add opt-in trace level logging of all sent and received messages
with a new property "shouldPrintWebSocketTrace" added to allow turning
the new logs on
* Add description for "shouldPrintWebSocketTrace" in README