### PR TITLE
set swift_version in podspec

### DIFF
--- a/ParseLiveQuery.podspec
+++ b/ParseLiveQuery.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.platform = :ios, :osx, :tvos
+  s.swift_version = '3.0'
 
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '9.0'


### PR DESCRIPTION
As of cocoapods 1.4.0 the `.swift-version` file is deprecated in favor of the podspec property
http://blog.cocoapods.org/CocoaPods-1.4.0/#swift-version-dsl