### PR TITLE
Bumps Bolts-Swift dependency

### DIFF
--- a/ParseLiveQuery.podspec
+++ b/ParseLiveQuery.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.module_name = 'ParseLiveQuery'
   
   s.dependency 'Parse', '~> 1.17.0'
-  s.dependency 'Bolts-Swift', '~> 1.3.0'
+  s.dependency 'Bolts-Swift', '~> 1.4.0'
   s.dependency 'Starscream', '~> 3.0.4'
   s.dependency 'Bolts', '~> 1.9.0'
 end


### PR DESCRIPTION
Using Swift 4 it's impossible to build this using CocoaPods as-is.

This bumps the version of Bolts-Swift to the version supporting Swift 4. I've done some brief manual testing and everything seems to be working fine.