### PR TITLE
Full Swift 4.2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jobs:
   include:
     - stage: distribution
       env: CocoaPods
+      script: bundle exec pod spec lint ParseLiveQuery.podspec --quick
       deploy:
         provider: script
         skip_cleanup: true

--- a/Examples/LiveQueryDemo-ObjC.xcodeproj/project.pbxproj
+++ b/Examples/LiveQueryDemo-ObjC.xcodeproj/project.pbxproj
@@ -244,7 +244,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.LiveQueryDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -257,7 +257,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.LiveQueryDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/Examples/LiveQueryDemo.xcodeproj/project.pbxproj
+++ b/Examples/LiveQueryDemo.xcodeproj/project.pbxproj
@@ -146,7 +146,7 @@
 				TargetAttributes = {
 					F509D5161CA9E4AE007B15B0 = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1010;
 					};
 				};
 			};
@@ -225,7 +225,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.LiveQueryDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -239,7 +239,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.parse.LiveQueryDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/ParseLiveQuery.podspec
+++ b/ParseLiveQuery.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.platform = :ios, :osx, :tvos
-  s.swift_version = '3.2'
+  s.swift_version = '4.2'
   s.cocoapods_version = '>= 1.4'
 
   s.ios.deployment_target = '8.0'

--- a/Sources/ParseLiveQuery.xcodeproj/project.pbxproj
+++ b/Sources/ParseLiveQuery.xcodeproj/project.pbxproj
@@ -489,10 +489,10 @@
 				TargetAttributes = {
 					F5903CE91BD999C500C3EFFE = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1010;
 					};
 					F5A9BFB61BE0248D00E78326 = {
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1010;
 					};
 				};
 			};
@@ -788,7 +788,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -823,7 +823,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -848,7 +848,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -872,7 +872,7 @@
 				PRODUCT_NAME = ParseLiveQuery;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -898,7 +898,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_INSTALL_OBJC_HEADER = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -924,7 +924,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_INSTALL_OBJC_HEADER = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Sources/ParseLiveQuery/ObjCCompat.swift
+++ b/Sources/ParseLiveQuery/ObjCCompat.swift
@@ -97,11 +97,11 @@ public struct ObjCCompat {
     open class Event: NSObject {
         /// Type of the event.
         @objc
-        open let type: PFLiveQueryEventType
+        public let type: PFLiveQueryEventType
 
         /// Object this event is for.
         @objc
-        open let object: PFObject
+        public let object: PFObject
 
         init(type: PFLiveQueryEventType, object: PFObject) {
             self.type = type


### PR DESCRIPTION
# Resolved issues
* Fix build error of LiveQueryDemo in Xcode 10.2 beta1
```
SWIFT_VERSION '3.0' is unsupported, supported versions are: 4.0, 4.2, 5.0. (in target 'LiveQueryDemo')
```
* Fix build errors of ParseLiveQuery when imported with Cocoapods in Xcode 10.2 beta1
```
SWIFT_VERSION ‘3.2’ is unsupported, supported versions are: 4.0, 4.2, 5.0. (in target ‘Bolts-Swift’)
SWIFT_VERSION ‘3.2’ is unsupported, supported versions are: 4.0, 4.2, 5.0. (in target ‘ParseLiveQuery’)
```

# Changes
* convert all targets to Swift 4.2
* set `swift_version` in the Podspec to 4.2

# Successful test cases
* Build of schemes "ParseLiveQuery-iOS" and "LiveQueryDemo" in Xcode 10.1 and Xcode 10.2.beta
* Build of  "ParseLiveQuery" in Xcode 10.1 and Xcode 10.2.beta when integrated with Cocapods and Podfile entry
```
pod 'ParseLiveQuery', :git => 'https://github.com/HeEAaD/ParseLiveQuery-iOS-OSX', :branch => 'swift-4.2'
```