### PR TITLE
Fix `pod lib lint`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,14 +50,6 @@ jobs:
       - checkout
       - run: *prepare
       - run: carthage build --no-skip-current --platform macos,ios
-  cocoapods:
-    <<: *defaults
-    steps:
-      - checkout
-      - run: *prepare
-      - run:  |
-          bundle exec pod repo update --silent;
-          pod lib lint ParseLiveQuery.podspec;
 
 workflows:
   version: 2
@@ -68,7 +60,6 @@ workflows:
       - demo
   nightly:
     jobs:
-      - cocoapods
       - carthage
     triggers:
       - schedule:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
     - /^v?[0-9]+\.[0-9]+\.[0-9]+(-.*)?$/
 language: objective-c
 os: osx
-osx_image: xcode9
+osx_image: xcode10.1
 cache:
   - cocoapods
 install:  bundle install
@@ -13,7 +13,7 @@ jobs:
   include:
     - stage: distribution
       env: CocoaPods
-      script: bundle exec pod spec lint ParseLiveQuery.podspec --quick
+      script: EXPANDED_CODE_SIGN_IDENTITY="-" EXPANDED_CODE_SIGN_IDENTITY_NAME="-" bundle exec pod lib lint --allow-warnings
       deploy:
         provider: script
         skip_cleanup: true

--- a/publish.sh
+++ b/publish.sh
@@ -2,4 +2,4 @@
 rvm use $(< .ruby-version) --install --binary --fuzzy
 gem install bundler
 bundle install
-bundle exec pod trunk push ParseLiveQuery.podspec --allow-warnings
+EXPANDED_CODE_SIGN_IDENTITY="-" EXPANDED_CODE_SIGN_IDENTITY_NAME="-" bundle exec pod trunk push ParseLiveQuery.podspec --allow-warnings


### PR DESCRIPTION
Make sure `pod trunk push` will succeed by running a full `pod lib lint` during development.
* run a complete pod lib lint
* upgrade to Xcode 10.1
* add a Xcode 10 workaround for CocoaPods < 1.6.0
