### PR TITLE
Refine encoding Date object in QueryEncoder

### DIFF
--- a/Sources/ParseLiveQuery/Internal/QueryEncoder.swift
+++ b/Sources/ParseLiveQuery/Internal/QueryEncoder.swift
@@ -37,7 +37,7 @@ extension Dictionary where Key: ExpressibleByStringLiteral, Value: AnyObject {
             } else if let object = val as? PFObject {
                 encodedQueryDictionary[key] = (try? PFPointerObjectEncoder.object().encode(object)) as? Value
             } else if let date = val as? Date {
-                encodedQueryDictionary[key] = date.encodedString as? Value
+                encodedQueryDictionary[key] = ["__type": "Date", "iso": date.encodedString] as? Value
             } else {
                 encodedQueryDictionary[key] = val
             }


### PR DESCRIPTION
Refine #114.

Date object should be encoded like:
[
  "__type": "Date",
  "iso": "2006-04-22T00:13:00.520Z"
]