### PR TITLE
Allows .or queries in LiveQuery

### DIFF
--- a/Sources/ParseLiveQuery/Internal/QueryEncoder.swift
+++ b/Sources/ParseLiveQuery/Internal/QueryEncoder.swift
@@ -30,7 +30,17 @@ extension Dictionary where Key: ExpressibleByStringLiteral, Value: AnyObject {
     var encodedQueryDictionary: Dictionary {
         var encodedQueryDictionary = Dictionary()
         for (key, val) in self {
-            if let dict = val as? [String:AnyObject] {
+             if let array = val as? [PFQuery] {
+                var queries:[Value] = []
+                for query in array {
+                    let queryState = query.value(forKey: "state") as AnyObject?
+                    if let conditions: [String:AnyObject] = queryState?.value(forKey: "conditions") as? [String:AnyObject], let encoded = conditions.encodedQueryDictionary as? Value {
+                        queries.append(encoded)
+                    }
+                }
+                encodedQueryDictionary[key] = queries as? Value
+            }
+            else if let dict = val as? [String:AnyObject] {
                 encodedQueryDictionary[key] = dict.encodedQueryDictionary as? Value
             } else if let geoPoint = val as? PFGeoPoint {
                 encodedQueryDictionary[key] = geoPoint.encodedDictionary as? Value


### PR DESCRIPTION
Fixes #156, #47, and #85. Allows orQuery to be encoded without throwing.