### PR TITLE
Fixes compatibility with Parse 1.17.3

### DIFF
--- a/Sources/ParseLiveQuery/Parse+LiveQuery.swift
+++ b/Sources/ParseLiveQuery/Parse+LiveQuery.swift
@@ -11,7 +11,7 @@ import Parse
 
 extension Parse {
     static func validatedCurrentConfiguration() -> ParseClientConfiguration {
-        guard let configuration = Parse.currentConfiguration() else {
+        guard let configuration = Parse.currentConfiguration else {
             preconditionFailure("Parse SDK is not initialized. Call Parse.initializeWithConfiguration() before loading live query client.")
         }
         return configuration


### PR DESCRIPTION
We fixed the compatibility with Parse iOS SDK 1.17.3.

It also fix this issue #211 .