### PR TITLE
Update Bolts dependency to only use the Tasks subspec.

### DIFF
--- a/ParseLiveQuery.podspec
+++ b/ParseLiveQuery.podspec
@@ -25,6 +25,6 @@ Pod::Spec.new do |s|
   s.dependency 'Parse', '~> 1.17.3'
   s.dependency 'Bolts-Swift', '~> 1.5.0'
   s.dependency 'Starscream', '~> 3.1.0'
-  s.dependency 'Bolts', '~> 1.9.0'
+  s.dependency 'Bolts/Tasks', '~> 1.9.0'
 
 end


### PR DESCRIPTION
This removes the import of Bolts/AppLinks by limiting the dependency to only Bolts/Tasks. Bolts/AppLinks includes some UIWebView code that can't be used anymore.

This will need to be updated and released before April 2020, since Apple will stop accepting new application uploads that have any references to UIWebView